### PR TITLE
Handle Gherkin comment lines in parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- **Gherkin parser: comment lines no longer drop scenarios.** Previously, a `# …` line between Background and the first Scenario (or between scenarios) caused **all scenarios in the file to be silently dropped**, with no error raised. The parser now recognizes `#`-prefixed lines as skippable wherever blank lines are valid (between sections, between steps, before Examples, before `Feature:`). Comments inside docstrings remain content (unchanged); comments inside data tables and trailing inline comments are still not supported.
+
+### Improvements
+
+- **Empty-feature warning at compile time.** `Cucumber.Compiler` now emits `IO.warn` if a feature file parses to zero scenarios — a defensive net for parser regressions of the shape above. **Heads-up for `--warnings-as-errors`:** projects that check in scaffold `.feature` files with no scenarios will now fail to compile until at least one scenario is added.
+
 ## v0.9.0 (2026-02-10)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Improvements
 
-- **Empty-feature warning at compile time.** `Cucumber.Compiler` now emits `IO.warn` if a feature file parses to zero scenarios — a defensive net for parser regressions of the shape above. **Heads-up for `--warnings-as-errors`:** projects that check in scaffold `.feature` files with no scenarios will now fail to compile until at least one scenario is added.
+- **Empty-feature warning.** `Cucumber.Compiler` now emits `IO.warn` if a feature file parses to zero scenarios — a defensive net for parser regressions of the shape above. The warning fires when `Cucumber.compile_features!/1` runs (typically from `test/test_helper.exs` at `mix test` time). **Heads-up for `mix test --warnings-as-errors`:** projects that check in scaffold `.feature` files with no scenarios will trip this and abort the test suite until at least one scenario is added. (`mix compile --warnings-as-errors` is unaffected — the warning is not emitted during `.ex` compilation.)
 
 ## v0.9.0 (2026-02-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bug Fixes
 
-- **Gherkin parser: comment lines no longer drop scenarios.** Previously, a `# …` line between Background and the first Scenario (or between scenarios) caused **all scenarios in the file to be silently dropped**, with no error raised. The parser now recognizes `#`-prefixed lines as skippable wherever blank lines are valid (between sections, between steps, before Examples, before `Feature:`). Comments inside docstrings remain content (unchanged); comments inside data tables and trailing inline comments are still not supported.
+- **Gherkin parser: comment lines no longer drop scenarios.** Previously, a `# …` line between Background and the first Scenario, between scenarios, between steps, or between a tag and the following `Scenario:` / `Examples:` keyword caused **scenarios in the file to be silently dropped**, with no error raised. The parser now recognizes `#`-prefixed lines as skippable wherever blank lines are valid (including interspersed within tag groups). Comments inside docstrings remain content (unchanged); comments inside data tables and trailing inline comments are still not supported.
+- **Parser no longer silently truncates on partial parses.** `Gherkin.Parser.parse/1` used to return a partial feature when the parser stopped before end of file — masking exactly the kind of bug above. It now raises `Gherkin.ParseError` if any non-whitespace content remains unconsumed.
 
 ### Improvements
 

--- a/lib/cucumber/compiler.ex
+++ b/lib/cucumber/compiler.ex
@@ -87,15 +87,24 @@ defmodule Cucumber.Compiler do
     module_name
   end
 
-  defp warn_on_empty_feature(%{scenarios: []} = feature) do
+  @doc false
+  # Public for testing. Emits a compile-time warning when a feature parses with
+  # zero scenarios — usually a sign the parser silently dropped them. The
+  # synthetic stacktrace makes editors highlight the warning on the feature
+  # file itself rather than inside the cucumber library.
+  def warn_on_empty_feature(%{scenarios: []} = feature) do
+    stacktrace = [
+      {__MODULE__, :compile_feature, 3, [file: String.to_charlist(feature.file), line: 1]}
+    ]
+
     IO.warn(
       "Cucumber: feature file #{feature.file} parsed with zero scenarios — " <>
         "scenarios may have been silently dropped by the parser.",
-      []
+      stacktrace
     )
   end
 
-  defp warn_on_empty_feature(_feature), do: :ok
+  def warn_on_empty_feature(_feature), do: :ok
 
   defp generate_module_name(file_path) do
     # Convert path like "test/features/authentication.feature"

--- a/lib/cucumber/compiler.ex
+++ b/lib/cucumber/compiler.ex
@@ -37,6 +37,8 @@ defmodule Cucumber.Compiler do
   end
 
   defp compile_feature(feature, step_registry, hook_modules) do
+    warn_on_empty_feature(feature)
+
     # Generate module name from feature file path
     module_name = generate_module_name(feature.file)
 
@@ -84,6 +86,16 @@ defmodule Cucumber.Compiler do
     [{^module_name, _}] = Code.compile_quoted(ast, feature.file)
     module_name
   end
+
+  defp warn_on_empty_feature(%{scenarios: []} = feature) do
+    IO.warn(
+      "Cucumber: feature file #{feature.file} parsed with zero scenarios — " <>
+        "scenarios may have been silently dropped by the parser.",
+      []
+    )
+  end
+
+  defp warn_on_empty_feature(_feature), do: :ok
 
   defp generate_module_name(file_path) do
     # Convert path like "test/features/authentication.feature"

--- a/lib/gherkin/parser.ex
+++ b/lib/gherkin/parser.ex
@@ -51,9 +51,10 @@ defmodule Gherkin.NimbleParser do
   # Gherkin treats these as content-less, so we skip them anywhere a blank line is valid.
   comment_line =
     optional_ws
-    |> concat(ignore(string("#")))
-    |> concat(ignore(utf8_string([not: ?\n, not: ?\r], min: 0)))
+    |> concat(string("#"))
+    |> concat(utf8_string([not: ?\n, not: ?\r], min: 0))
     |> concat(eol)
+    |> ignore()
 
   # Non-content line: blank or comment. Both are skipped between meaningful tokens.
   skippable_line = choice([blank_line, comment_line])

--- a/lib/gherkin/parser.ex
+++ b/lib/gherkin/parser.ex
@@ -47,8 +47,19 @@ defmodule Gherkin.NimbleParser do
     |> concat(newline)
     |> ignore()
 
-  # Zero or more blank lines
-  blank_lines = repeat(blank_line)
+  # Comment line (optional whitespace, then # and the rest of the line).
+  # Gherkin treats these as content-less, so we skip them anywhere a blank line is valid.
+  comment_line =
+    optional_ws
+    |> concat(ignore(string("#")))
+    |> concat(ignore(utf8_string([not: ?\n, not: ?\r], min: 0)))
+    |> concat(eol)
+
+  # Non-content line: blank or comment. Both are skipped between meaningful tokens.
+  skippable_line = choice([blank_line, comment_line])
+
+  # Zero or more blank or comment lines
+  blank_lines = repeat(skippable_line)
 
   # ============================================================
   # LEVEL 2: KEYWORDS
@@ -195,12 +206,12 @@ defmodule Gherkin.NimbleParser do
     |> reduce({__MODULE__, :build_step, []})
     |> label("step")
 
-  # Multiple steps (also skip blank lines between steps)
+  # Multiple steps (also skip blank/comment lines between steps)
   steps =
     repeat(
       choice([
         step,
-        lookahead_not(section_marker) |> concat(blank_line)
+        lookahead_not(section_marker) |> concat(skippable_line)
       ])
     )
     |> reduce({__MODULE__, :filter_steps, []})

--- a/lib/gherkin/parser.ex
+++ b/lib/gherkin/parser.ex
@@ -122,9 +122,12 @@ defmodule Gherkin.NimbleParser do
     |> wrap()
     |> label("tag line")
 
-  # Multiple tag lines (before features, scenarios, examples)
+  # Multiple tag lines (before features, scenarios, examples).
+  # Blank and comment lines may be interspersed (e.g. between two @tag lines,
+  # or between the last @tag and the following keyword). flatten_tags filters
+  # to binaries so skippable_line's empty output is harmless.
   tags =
-    repeat(tag_line)
+    repeat(choice([tag_line, skippable_line]))
     |> reduce({__MODULE__, :flatten_tags, []})
 
   # --- Data Tables ---
@@ -243,10 +246,11 @@ defmodule Gherkin.NimbleParser do
     ignore(examples_keyword)
     |> concat(rest_of_line)
 
-  # Lookahead to verify Examples: keyword follows tags
+  # Lookahead to verify Examples: keyword follows tags (with optional
+  # interspersed blank/comment lines, matching the `tags` combinator above).
   examples_lookahead =
     lookahead(
-      repeat(tag_line)
+      repeat(choice([tag_line, skippable_line]))
       |> concat(optional_ws)
       |> concat(examples_keyword)
     )
@@ -366,9 +370,19 @@ defmodule Gherkin.NimbleParser do
       {:ok, [feature], "", _context, _line, _offset} ->
         feature
 
-      {:ok, [feature], _rest, _context, _line, _offset} ->
-        # Partial parse - return what we have
-        feature
+      {:ok, [feature], rest, _context, {line, col}, _offset} ->
+        # Trailing whitespace is benign; non-whitespace content means the
+        # parser silently stopped mid-file (e.g. on a malformed line).
+        # Raising prevents scenarios from being dropped without notice.
+        if String.trim(rest) == "" do
+          feature
+        else
+          raise Gherkin.ParseError,
+            message: "Unexpected content; parser stopped before end of file",
+            line: line,
+            column: col,
+            rest: String.slice(rest, 0, 80)
+        end
 
       {:error, message, rest, _context, {line, col}, _offset} ->
         raise Gherkin.ParseError,

--- a/test/cucumber/compiler_test.exs
+++ b/test/cucumber/compiler_test.exs
@@ -1,7 +1,9 @@
 defmodule Cucumber.CompilerTest do
   use ExUnit.Case, async: true
 
-  alias Gherkin.{Examples, Scenario, ScenarioOutline, Step}
+  import ExUnit.CaptureIO
+
+  alias Gherkin.{Examples, Feature, Scenario, ScenarioOutline, Step}
 
   describe "expand_all_scenarios/1" do
     test "passes through regular scenarios unchanged" do
@@ -205,6 +207,32 @@ defmodule Cucumber.CompilerTest do
       assert Enum.at(result, 0).name == "Multi-examples (first: row 1)"
       assert Enum.at(result, 1).name == "Multi-examples (second: row 1)"
       assert Enum.at(result, 2).name == "Multi-examples (second: row 2)"
+    end
+  end
+
+  describe "warn_on_empty_feature/1" do
+    test "warns when the feature has zero scenarios" do
+      feature = %Feature{name: "empty", scenarios: [], tags: []}
+      feature = Map.put(feature, :file, "test/features/empty.feature")
+
+      stderr = capture_io(:stderr, fn -> Cucumber.Compiler.warn_on_empty_feature(feature) end)
+
+      assert stderr =~ "test/features/empty.feature"
+      assert stderr =~ "zero scenarios"
+    end
+
+    test "is silent when the feature has at least one scenario" do
+      feature = %Feature{
+        name: "non-empty",
+        scenarios: [%Scenario{name: "a", steps: [], tags: [], line: 1}],
+        tags: []
+      }
+
+      feature = Map.put(feature, :file, "test/features/non_empty.feature")
+
+      stderr = capture_io(:stderr, fn -> Cucumber.Compiler.warn_on_empty_feature(feature) end)
+
+      assert stderr == ""
     end
   end
 end

--- a/test/gherkin_test.exs
+++ b/test/gherkin_test.exs
@@ -601,5 +601,80 @@ defmodule Gherkin.ParserTest do
       [examples] = outline.examples
       assert examples.table_body == [["one"], ["two"]]
     end
+
+    test "comment line between a tag and Scenario: keyword is skipped" do
+      gherkin = """
+      Feature: Commented
+
+      Scenario: First
+        Given a thing
+
+      @wip
+      # comment after tag
+      Scenario: Second
+        Given another thing
+      """
+
+      result = Gherkin.Parser.parse(gherkin)
+
+      assert Enum.map(result.scenarios, & &1.name) == ["First", "Second"]
+      [_first, second] = result.scenarios
+      assert second.tags == ["wip"]
+    end
+
+    test "comment line between two tags on the same scenario is skipped" do
+      gherkin = """
+      Feature: Commented
+
+      @wip
+      # between tags
+      @smoke
+      Scenario: Double-tagged
+        Given a thing
+      """
+
+      result = Gherkin.Parser.parse(gherkin)
+
+      [scenario] = result.scenarios
+      assert scenario.tags == ["wip", "smoke"]
+    end
+
+    test "raises when parser stops before consuming end of file" do
+      # Trailing junk after the last scenario should not silently disappear.
+      gherkin = """
+      Feature: F
+
+      Scenario: First
+        Given a step
+
+      this is not valid gherkin
+      """
+
+      assert_raise Gherkin.ParseError, ~r/Unexpected content/, fn ->
+        Gherkin.Parser.parse(gherkin)
+      end
+    end
+
+    test "comment line between an Examples tag and Examples: keyword is skipped" do
+      gherkin = """
+      Feature: Commented Outline
+
+      Scenario Outline: With tagged examples
+        Given I have <value>
+
+        @smoke
+        # tagged examples
+        Examples:
+          | value |
+          | one   |
+      """
+
+      result = Gherkin.Parser.parse(gherkin)
+
+      [outline] = result.scenarios
+      [examples] = outline.examples
+      assert examples.tags == ["smoke"]
+      assert examples.table_body == [["one"]]
+    end
   end
 end

--- a/test/gherkin_test.exs
+++ b/test/gherkin_test.exs
@@ -506,4 +506,100 @@ defmodule Gherkin.ParserTest do
       end
     end
   end
+
+  describe "parse/1 with comment lines" do
+    test "comment line between Background and first Scenario is skipped" do
+      gherkin = """
+      Feature: Commented
+
+        Background:
+          Given a user exists
+
+        # ===== Section Marker =====
+
+        Scenario: First
+          Given a thing
+          Then it works
+
+        Scenario: Second
+          Given another thing
+          Then it also works
+      """
+
+      result = Gherkin.Parser.parse(gherkin)
+
+      assert length(result.scenarios) == 2
+      assert Enum.map(result.scenarios, & &1.name) == ["First", "Second"]
+    end
+
+    test "comment line between scenarios is skipped" do
+      gherkin = """
+      Feature: Commented
+
+      Scenario: First
+        Given a thing
+
+      # divider comment
+
+      Scenario: Second
+        Given another thing
+      """
+
+      result = Gherkin.Parser.parse(gherkin)
+
+      assert Enum.map(result.scenarios, & &1.name) == ["First", "Second"]
+    end
+
+    test "comment line between steps is skipped" do
+      gherkin = """
+      Feature: Commented
+
+      Scenario: Steps with comments
+        Given step one
+        # an explanatory comment
+        When step two
+        Then step three
+      """
+
+      result = Gherkin.Parser.parse(gherkin)
+
+      [scenario] = result.scenarios
+      assert Enum.map(scenario.steps, & &1.text) == ["step one", "step two", "step three"]
+    end
+
+    test "comment line before Feature keyword is skipped" do
+      gherkin = """
+      # top-of-file note
+      Feature: Commented
+        Scenario: x
+          Given a thing
+      """
+
+      result = Gherkin.Parser.parse(gherkin)
+
+      assert result.name == "Commented"
+      assert length(result.scenarios) == 1
+    end
+
+    test "comment line before Examples block is skipped" do
+      gherkin = """
+      Feature: Commented Outline
+
+      Scenario Outline: With comments
+        Given I have <value>
+
+        # values to try
+        Examples:
+          | value |
+          | one   |
+          | two   |
+      """
+
+      result = Gherkin.Parser.parse(gherkin)
+
+      [outline] = result.scenarios
+      [examples] = outline.examples
+      assert examples.table_body == [["one"], ["two"]]
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes the silent-scenario-drop class of bugs in the Gherkin parser, reported downstream at huddlz-hq/huddlz#220.

**Parser fixes**

- **Comment lines no longer drop scenarios.** A `# …` line between Background and the first Scenario, between scenarios, between steps, or interspersed within a tag group (between two `@tag` lines, or between the last `@tag` and the following `Scenario:` / `Examples:` keyword) used to silently drop the surrounding scenarios. Comments are now recognized wherever blank lines are valid. Comments inside docstrings remain content (unchanged).
- **No more partial-parse fallback.** `Gherkin.Parser.parse/1` used to return whatever it had parsed when it stopped mid-file. That fallback is what allowed the bugs above to go unnoticed. It now raises `Gherkin.ParseError` on any non-whitespace unconsumed rest.

**Compiler defensive net**

- `Cucumber.Compiler` emits `IO.warn` (with a synthetic stacktrace pointing at the offending `.feature` file) when a feature compiles to zero scenarios — a second line of defence for parser regressions of this shape.
- **Heads-up:** `mix test --warnings-as-errors` will abort the suite on a zero-scenario feature file. `mix compile --warnings-as-errors` is unaffected.

**Out of scope (still unsupported, called out in CHANGELOG):**
- Comments inside data tables.
- Trailing inline comments (correct per Gherkin spec — comments must be whole-line).

## Test plan
- [x] `mix precommit` clean (format, credo, test) — 189 tests, 0 failures
- [x] 10 new tests covering: comments between Background and first Scenario, between scenarios, between steps, before Feature, before Examples, between tag and Scenario:, between two tags on one scenario, between tag and Examples:, partial-parse raise, plus two new compiler tests for `warn_on_empty_feature/1` (warn + silent branches)
- [x] Two Codex adversarial reviews — first surfaced a tag+comment gap that's now fixed; re-review approves