### PR TITLE
CI: require Elixir 1.20 to pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ["1.19"]
+        elixir: ["1.19", "1.20.1"]
         otp: ["28"]
     steps:
       - uses: actions/checkout@v4
@@ -33,33 +33,6 @@ jobs:
           key: ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-
-
-      - run: mix deps.get
-      - run: mix compile --warnings-as-errors
-      - run: mix format --check-formatted
-      - run: mix credo --strict
-      - run: mix test
-
-  test-elixir-rc:
-    name: Elixir 1.20-rc (allow failure)
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: erlef/setup-beam@v1
-        with:
-          elixir-version: "1.20.0-rc.1"
-          otp-version: "28"
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            deps
-            _build
-          key: ${{ runner.os }}-mix-1.20-rc-28-${{ hashFiles('mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-1.20-rc-28-
 
       - run: mix deps.get
       - run: mix compile --warnings-as-errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ["1.19", "1.20.1"]
-        otp: ["28"]
+        include:
+          - elixir: "1.19"
+            otp: "28"
+          - elixir: "1.20.1"
+            otp: "28"
+          - elixir: "1.20.1"
+            otp: "29"
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `Cucumber.Compiler.compile_feature!/3` is now public (`@doc false`) so test harnesses can compile a single parsed feature against an explicit step registry.
 - Removed an unreachable clause in `Cucumber.Runtime` exception formatting that failed `mix compile --warnings-as-errors` under Elixir 1.20's type checker.
 - **Bumped Credo** to 1.7.19 — 1.7.16 crashed on Elixir 1.20's new sigil token format, breaking `mix precommit`.
+- **CI: Elixir 1.20 is now required.** With 1.20.1 released, the allow-failure 1.20-rc job is replaced by a required matrix entry; CI now runs Elixir 1.19 and 1.20.1 (both OTP 28) and both must pass.
 
 ## v0.9.1 (2026-05-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - `Cucumber.Compiler.compile_feature!/3` is now public (`@doc false`) so test harnesses can compile a single parsed feature against an explicit step registry.
 - Removed an unreachable clause in `Cucumber.Runtime` exception formatting that failed `mix compile --warnings-as-errors` under Elixir 1.20's type checker.
 - **Bumped Credo** to 1.7.19 — 1.7.16 crashed on Elixir 1.20's new sigil token format, breaking `mix precommit`.
-- **CI: Elixir 1.20 is now required.** With 1.20.1 released, the allow-failure 1.20-rc job is replaced by required matrix entries; CI now runs Elixir 1.19/OTP 28, 1.20.1/OTP 28, and 1.20.1/OTP 29, and all must pass.
 
 ## v0.9.1 (2026-05-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - `Cucumber.Compiler.compile_feature!/3` is now public (`@doc false`) so test harnesses can compile a single parsed feature against an explicit step registry.
 - Removed an unreachable clause in `Cucumber.Runtime` exception formatting that failed `mix compile --warnings-as-errors` under Elixir 1.20's type checker.
 - **Bumped Credo** to 1.7.19 — 1.7.16 crashed on Elixir 1.20's new sigil token format, breaking `mix precommit`.
-- **CI: Elixir 1.20 is now required.** With 1.20.1 released, the allow-failure 1.20-rc job is replaced by a required matrix entry; CI now runs Elixir 1.19 and 1.20.1 (both OTP 28) and both must pass.
+- **CI: Elixir 1.20 is now required.** With 1.20.1 released, the allow-failure 1.20-rc job is replaced by required matrix entries; CI now runs Elixir 1.19/OTP 28, 1.20.1/OTP 28, and 1.20.1/OTP 29, and all must pass.
 
 ## v0.9.1 (2026-05-12)
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+erlang = "29.0.1"
+elixir = "1.20.1-otp-29"


### PR DESCRIPTION
Elixir 1.20.1 is out, so the 1.20 job graduates from allow-failure to required:

- Test matrix is now three required combinations: Elixir 1.19 / OTP 28, Elixir 1.20.1 / OTP 28, and Elixir 1.20.1 / OTP 29.
- The separate `test-elixir-rc` allow-failure job (pinned to 1.20.0-rc.1) is removed — the matrix entries supersede it.

Groundwork from #30 makes this green on 1.20: the `--warnings-as-errors` type-checker fix and the credo 1.7.19 bump. The OTP 29 combination also matches the local dev environment (1.20 on OTP 29).