### PR TITLE
Parser: descriptions under all section headers + backtick docstrings with media types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- **Descriptions under any section header now parse** (#17). Standard Gherkin allows free-form description text after `Background:`, `Scenario:`, `Scenario Outline:`, and `Examples:` headers; previously such lines caused a parse error that made the whole feature file unusable. Descriptions are now captured on the corresponding structs (`description` field, default `""`), and the feature-level description — previously discarded — is captured on `Gherkin.Feature.description`. Descriptions never affect execution.
+- **Parser no longer hangs on a feature ending in a description.** A latent zero-width repeat in the description combinator could loop forever at end of input (e.g. a feature whose last line is description text, or a scenario with no steps at EOF).
+
+### New Features
+
+- **Backtick docstrings and media types** (#18). Docstrings can be delimited with ``` ``` ``` as an alternative to `"""`; the closing delimiter must match the opening one, and either delimiter style is plain content inside the other. An optional media type may follow the opening delimiter (e.g. ` ```json `) and is available as `Gherkin.Step.docstring_media_type` and `context.docstring_media_type` in step definitions. `context.docstring` remains a plain string.
+
 ### Improvements
 
 - **Behavior test harness.** New `Cucumber.BehaviorCase` test-case template (test-only, in `test/support/`) runs a Gherkin source against explicit step/hook modules through the real compile pipeline in a nested ExUnit run and reports the outcome — making failing, undefined, and otherwise broken scenarios assertable in the test suite. Behavior fixtures from the [Cucumber Compatibility Kit](https://github.com/cucumber/compatibility-kit) are vendored under `test/fixtures/cck/` (MIT) and backed by behavior tests asserting reference outcomes.

--- a/docs/feature_files.md
+++ b/docs/feature_files.md
@@ -154,6 +154,38 @@ Scenario: Submit feedback
   Then my feedback should be recorded
 ```
 
+Backticks work as an alternative delimiter, and either delimiter may carry a
+media type annotation after the opening line:
+
+````gherkin
+Scenario: Submit structured feedback
+  When I submit the following feedback:
+    ```json
+    {"rating": 5, "comment": "Keep up the good work!"}
+    ```
+  Then my feedback should be recorded
+````
+
+The content arrives in your step as `context.docstring`; the media type (if
+given) as `context.docstring_media_type`.
+
+### Descriptions
+
+Free-form description text can follow any section header — `Feature:`,
+`Background:`, `Scenario:`, `Scenario Outline:`, or `Examples:` — until the
+first step, tag, or table row. Descriptions are purely informational and never
+affect execution:
+
+```gherkin
+Scenario: Adding an item to an empty cart
+  Carts start empty for new sessions, so this is the
+  most common path through checkout.
+
+  Given I am on the product page for "Ergonomic Keyboard"
+  When I click "Add to Cart"
+  Then my cart should contain 1 item
+```
+
 ## File Organization
 
 Feature files should be placed in a `test/features/` directory and have a `.feature` extension. Organize them logically by feature or domain area:

--- a/lib/cucumber/runtime.ex
+++ b/lib/cucumber/runtime.ex
@@ -93,7 +93,7 @@ defmodule Cucumber.Runtime do
     context
     |> Map.put(:args, args)
     |> add_datatable(step.datatable)
-    |> add_docstring(step.docstring)
+    |> add_docstring(step.docstring, step.docstring_media_type)
   end
 
   defp add_datatable(context, nil), do: context
@@ -113,10 +113,16 @@ defmodule Cucumber.Runtime do
     Map.put(context, :datatable, table_data)
   end
 
-  defp add_docstring(context, nil), do: context
+  defp add_docstring(context, nil, _media_type), do: context
 
-  defp add_docstring(context, docstring) do
+  defp add_docstring(context, docstring, nil) do
     Map.put(context, :docstring, docstring)
+  end
+
+  defp add_docstring(context, docstring, media_type) do
+    context
+    |> Map.put(:docstring, docstring)
+    |> Map.put(:docstring_media_type, media_type)
   end
 
   defp process_step_result(result, context) do

--- a/lib/gherkin.ex
+++ b/lib/gherkin.ex
@@ -24,10 +24,11 @@ defmodule Gherkin.Background do
   A Background contains steps that are run before each scenario in the feature.
   It allows you to define common setup steps that apply to all scenarios.
   """
-  defstruct steps: []
+  defstruct steps: [], description: ""
 
   @type t :: %__MODULE__{
-          steps: [Gherkin.Step.t()]
+          steps: [Gherkin.Step.t()],
+          description: String.t()
         }
 end
 
@@ -36,13 +37,15 @@ defmodule Gherkin.Scenario do
   Represents a Gherkin Scenario section.
 
   A Scenario is a concrete example that illustrates a business rule.
-  It consists of a name, a list of steps, optional tags for filtering,
-  and the line number where it appears in the source file.
+  It consists of a name, an optional free-form description, a list of steps,
+  optional tags for filtering, and the line number where it appears in the
+  source file.
   """
-  defstruct name: "", steps: [], tags: [], line: nil
+  defstruct name: "", description: "", steps: [], tags: [], line: nil
 
   @type t :: %__MODULE__{
           name: String.t(),
+          description: String.t(),
           steps: [Gherkin.Step.t()],
           tags: [String.t()],
           line: non_neg_integer() | nil
@@ -57,10 +60,11 @@ defmodule Gherkin.ScenarioOutline do
   from Examples tables. Placeholders in step text use `<name>` syntax and are
   substituted with values from each row of the Examples table.
   """
-  defstruct name: "", steps: [], tags: [], examples: [], line: nil
+  defstruct name: "", description: "", steps: [], tags: [], examples: [], line: nil
 
   @type t :: %__MODULE__{
           name: String.t(),
+          description: String.t(),
           steps: [Gherkin.Step.t()],
           tags: [String.t()],
           examples: [Gherkin.Examples.t()],
@@ -74,12 +78,14 @@ defmodule Gherkin.Examples do
 
   Each Examples block contains a table of data used to parameterize the outline.
   The first row contains headers (placeholder names), and subsequent rows contain
-  values to substitute. Examples blocks can have optional names and tags.
+  values to substitute. Examples blocks can have optional names, descriptions,
+  and tags.
   """
-  defstruct name: "", tags: [], table_header: [], table_body: [], line: nil
+  defstruct name: "", description: "", tags: [], table_header: [], table_body: [], line: nil
 
   @type t :: %__MODULE__{
           name: String.t(),
+          description: String.t(),
           tags: [String.t()],
           table_header: [String.t()],
           table_body: [[String.t()]],
@@ -94,16 +100,24 @@ defmodule Gherkin.Step do
   A Step is a single action or assertion in a scenario. It consists of:
   - keyword: The step type (Given, When, Then, And, But, or *)
   - text: The step text that matches step definitions
-  - docstring: Optional multi-line text block (triple-quoted)
+  - docstring: Optional multi-line text block (delimited by `\"\"\"` or triple backticks)
+  - docstring_media_type: Optional media type annotation on the opening
+    docstring delimiter (e.g. `json` in `\"\"\"json`)
   - datatable: Optional table data (pipe-delimited)
   - line: Line number in the source file
   """
-  defstruct keyword: "", text: "", docstring: nil, datatable: nil, line: nil
+  defstruct keyword: "",
+            text: "",
+            docstring: nil,
+            docstring_media_type: nil,
+            datatable: nil,
+            line: nil
 
   @type t :: %__MODULE__{
           keyword: String.t(),
           text: String.t(),
           docstring: String.t() | nil,
+          docstring_media_type: String.t() | nil,
           datatable: [[String.t()]] | nil,
           line: non_neg_integer() | nil
         }

--- a/lib/gherkin/parser.ex
+++ b/lib/gherkin/parser.ex
@@ -156,27 +156,34 @@ defmodule Gherkin.NimbleParser do
     |> label("data table")
 
   # --- DocStrings ---
-  docstring_delimiter = string(~s("""))
+  # Gherkin supports two docstring delimiters: """ and ``` (backticks).
+  # The closing delimiter must match the opening one, so each delimiter gets
+  # its own combinator — which also makes the other delimiter style plain
+  # content for free. An optional media type (e.g. json in ```json) may
+  # follow the opening delimiter.
+  docstring_for = fn delimiter ->
+    # Content line (anything that's not this docstring's closing delimiter)
+    content_line =
+      lookahead_not(
+        optional_ws
+        |> concat(string(delimiter))
+      )
+      |> concat(utf8_string([not: ?\n, not: ?\r], min: 0))
+      |> ignore(newline)
 
-  # Content line (anything that's not the closing delimiter)
-  docstring_content_line =
-    lookahead_not(
-      optional_ws
-      |> concat(docstring_delimiter)
-    )
-    |> concat(utf8_string([not: ?\n, not: ?\r], min: 0))
-    |> ignore(newline)
-
-  # Full docstring
-  docstring =
     optional_ws
-    |> ignore(docstring_delimiter)
+    |> ignore(string(delimiter))
+    |> concat(rest_of_line |> unwrap_and_tag(:media_type))
     |> concat(eol)
-    |> repeat(docstring_content_line)
+    |> repeat(content_line)
     |> concat(optional_ws)
-    |> ignore(docstring_delimiter)
+    |> ignore(string(delimiter))
     |> concat(eol)
-    |> reduce({__MODULE__, :join_docstring, []})
+  end
+
+  docstring =
+    choice([docstring_for.(~s(""")), docstring_for.("```")])
+    |> reduce({__MODULE__, :build_docstring, []})
     |> unwrap_and_tag(:docstring)
     |> label("docstring")
 
@@ -221,6 +228,72 @@ defmodule Gherkin.NimbleParser do
     |> reduce({__MODULE__, :filter_steps, []})
 
   # ============================================================
+  # LEVEL 4.5: DESCRIPTIONS
+  # ============================================================
+  # Free-form description text may follow any section header (Feature:,
+  # Background:, Scenario:, Scenario Outline:, Examples:) until the first
+  # step, tag, table row, docstring, or next section keyword. Blank lines
+  # are part of the description region (captured as empty lines); comment
+  # lines are skipped. The builder dedents and trims the collected lines.
+
+  # A description line must consume at least one byte — content or a bare
+  # newline — or repeat() would loop forever on a zero-width match at the
+  # end of input.
+  description_line_content =
+    choice([
+      utf8_string([not: ?\n, not: ?\r], min: 1) |> concat(eol),
+      newline |> replace("")
+    ])
+
+  # At feature level there are no steps yet, so lines starting with step
+  # keywords (including * bullets) are still description.
+  feature_description_line =
+    lookahead_not(
+      optional_ws
+      |> choice([
+        background_keyword,
+        scenario_keyword,
+        scenario_outline_keyword,
+        examples_keyword,
+        string("@")
+      ])
+    )
+    |> lookahead_not(optional_ws |> concat(string("#")))
+    |> concat(description_line_content)
+
+  feature_description =
+    repeat(choice([comment_line, feature_description_line]))
+    |> reduce({__MODULE__, :build_description, []})
+    |> unwrap_and_tag(:description)
+
+  # Inside a section, a line starting with a step keyword belongs to the
+  # steps (the keyword must be followed by whitespace, so words like
+  # "Givenness" stay description). Table rows and docstring delimiters
+  # terminate the description so malformed placement still errors.
+  section_description_line =
+    lookahead_not(
+      optional_ws
+      |> choice([
+        step_keyword |> concat(horizontal_ws),
+        background_keyword,
+        scenario_keyword,
+        scenario_outline_keyword,
+        examples_keyword,
+        string("@"),
+        string("|"),
+        string(~s(""")),
+        string("```")
+      ])
+    )
+    |> lookahead_not(optional_ws |> concat(string("#")))
+    |> concat(description_line_content)
+
+  section_description =
+    repeat(choice([comment_line, section_description_line]))
+    |> reduce({__MODULE__, :build_description, []})
+    |> unwrap_and_tag(:description)
+
+  # ============================================================
   # LEVEL 5: SCENARIOS
   # ============================================================
 
@@ -235,7 +308,7 @@ defmodule Gherkin.NimbleParser do
   background =
     optional_ws
     |> concat(background_name)
-    |> ignore(blank_lines)
+    |> concat(section_description)
     |> concat(steps |> tag(:steps))
     |> reduce({__MODULE__, :build_background, []})
     |> unwrap_and_tag(:background)
@@ -255,7 +328,7 @@ defmodule Gherkin.NimbleParser do
       |> concat(examples_keyword)
     )
 
-  # Examples block (tags + name + table)
+  # Examples block (tags + name + description + table)
   examples_block =
     ignore(blank_lines)
     |> concat(examples_lookahead)
@@ -263,7 +336,7 @@ defmodule Gherkin.NimbleParser do
     |> concat(optional_ws)
     |> line(examples_name)
     |> concat(eol)
-    |> ignore(blank_lines)
+    |> concat(section_description)
     |> concat(times(table_row, min: 1) |> tag(:table))
     |> reduce({__MODULE__, :build_examples, []})
     |> label("examples block")
@@ -280,7 +353,7 @@ defmodule Gherkin.NimbleParser do
     |> concat(optional_ws)
     |> line(scenario_name)
     |> concat(eol)
-    |> ignore(blank_lines)
+    |> concat(section_description)
     |> concat(steps |> tag(:steps))
     |> reduce({__MODULE__, :build_scenario, []})
     |> label("scenario")
@@ -297,7 +370,7 @@ defmodule Gherkin.NimbleParser do
     |> concat(optional_ws)
     |> line(outline_name)
     |> concat(eol)
-    |> ignore(blank_lines)
+    |> concat(section_description)
     |> concat(steps |> tag(:steps))
     |> concat(times(examples_block, min: 1) |> tag(:examples))
     |> reduce({__MODULE__, :build_scenario_outline, []})
@@ -322,29 +395,13 @@ defmodule Gherkin.NimbleParser do
     |> concat(rest_of_line)
     |> concat(eol)
 
-  # Feature description (lines between feature name and first scenario/background)
-  # A description line is any line that's not a section start or tag
-  description_line =
-    lookahead_not(
-      optional_ws
-      |> choice([
-        background_keyword,
-        scenario_keyword,
-        scenario_outline_keyword,
-        string("@")
-      ])
-    )
-    |> concat(rest_of_line)
-    |> concat(eol)
-    |> ignore()
-
   # Full feature file parser
   feature =
     ignore(blank_lines)
     |> concat(tags |> tag(:tags))
     |> concat(optional_ws)
     |> concat(feature_name |> unwrap_and_tag(:name))
-    |> ignore(repeat(choice([blank_line, description_line])))
+    |> concat(feature_description)
     |> optional(background)
     |> concat(repeat(scenario_definition) |> tag(:scenarios))
     |> reduce({__MODULE__, :build_feature, []})
@@ -398,6 +455,15 @@ defmodule Gherkin.NimbleParser do
   # ============================================================
 
   @doc false
+  # Builds the {content, media_type} pair for a docstring from the parser
+  # output: a tagged media type (text after the opening delimiter) followed
+  # by the raw content lines.
+  def build_docstring([{:media_type, media_type} | lines]) do
+    media_type = if media_type == "", do: nil, else: media_type
+    {join_docstring(lines), media_type}
+  end
+
+  @doc false
   def join_docstring(lines) do
     # Find minimum indentation of non-empty lines
     min_indent =
@@ -410,6 +476,17 @@ defmodule Gherkin.NimbleParser do
     lines
     |> Enum.map_join("\n", &strip_indent(&1, min_indent))
     |> String.trim_trailing()
+  end
+
+  @doc false
+  # Joins captured description lines: dedents to the minimum indentation of
+  # non-blank lines, preserves interior blank lines, and drops leading and
+  # trailing blank lines.
+  def build_description(lines) do
+    lines
+    |> Enum.map(&String.trim_trailing/1)
+    |> join_docstring()
+    |> String.trim_leading("\n")
   end
 
   defp count_leading_spaces(line) do
@@ -452,17 +529,18 @@ defmodule Gherkin.NimbleParser do
     {step_data, attachment} = extract_step_parts(args)
     {[keyword, text], {line_num, _offset}} = step_data
 
-    {docstring, datatable} =
+    {docstring, docstring_media_type, datatable} =
       case attachment do
-        {:docstring, ds} -> {ds, nil}
-        {:datatable, dt} -> {nil, dt}
-        nil -> {nil, nil}
+        {:docstring, {content, media_type}} -> {content, media_type, nil}
+        {:datatable, dt} -> {nil, nil, dt}
+        nil -> {nil, nil, nil}
       end
 
     %Step{
       keyword: keyword,
       text: text,
       docstring: docstring,
+      docstring_media_type: docstring_media_type,
       datatable: datatable,
       line: line_num - 1
     }
@@ -481,7 +559,8 @@ defmodule Gherkin.NimbleParser do
     steps = extract_tagged(args, :steps)
 
     %Background{
-      steps: steps
+      steps: steps,
+      description: extract_tagged_single(args, :description) || ""
     }
   end
 
@@ -495,6 +574,7 @@ defmodule Gherkin.NimbleParser do
 
     %Examples{
       name: name,
+      description: extract_tagged_single(args, :description) || "",
       tags: tags,
       table_header: header,
       table_body: body,
@@ -502,8 +582,11 @@ defmodule Gherkin.NimbleParser do
     }
   end
 
-  defp extract_examples_name(args), do: extract_name_from_args(args, [:tags, :table])
-  defp extract_scenario_name(args), do: extract_name_from_args(args, [:tags, :steps, :examples])
+  defp extract_examples_name(args),
+    do: extract_name_from_args(args, [:tags, :table, :description])
+
+  defp extract_scenario_name(args),
+    do: extract_name_from_args(args, [:tags, :steps, :examples, :description])
 
   defp extract_name_from_args([{tag, _} | rest], skip_tags) when is_atom(tag) do
     if tag in skip_tags,
@@ -533,6 +616,7 @@ defmodule Gherkin.NimbleParser do
 
     %Scenario{
       name: name,
+      description: extract_tagged_single(args, :description) || "",
       steps: steps,
       tags: tags,
       line: if(line_num, do: line_num - 1, else: nil)
@@ -548,6 +632,7 @@ defmodule Gherkin.NimbleParser do
 
     %ScenarioOutline{
       name: name,
+      description: extract_tagged_single(args, :description) || "",
       steps: steps,
       tags: tags,
       examples: examples,
@@ -564,7 +649,7 @@ defmodule Gherkin.NimbleParser do
 
     %Feature{
       name: name,
-      description: "",
+      description: extract_tagged_single(args, :description) || "",
       tags: tags,
       background: background,
       scenarios: scenarios

--- a/test/cucumber/behavior/behavior_case_test.exs
+++ b/test/cucumber/behavior/behavior_case_test.exs
@@ -277,6 +277,32 @@ defmodule Cucumber.BehaviorCaseTest do
     end
   end
 
+  describe "descriptions" do
+    test "scenarios with descriptions at every level execute their steps normally" do
+      run =
+        run_feature(
+          """
+          Feature: described feature
+            The feature description does not affect execution.
+
+            Background:
+              Background descriptions do not affect execution either.
+
+              Given a passing step
+
+            Scenario: described scenario
+              Nor do scenario descriptions.
+
+              Given another passing step
+          """,
+          steps: [BasicSteps]
+        )
+
+      assert run.passed == 1
+      assert run.events == [:passing_step, :another_passing_step]
+    end
+  end
+
   describe "undefined steps" do
     test "an undefined step fails with a definition suggestion" do
       run =

--- a/test/cucumber/behavior/cck_behavior_test.exs
+++ b/test/cucumber/behavior/cck_behavior_test.exs
@@ -141,6 +141,15 @@ defmodule Cucumber.CckBehaviorTest do
     end
   end
 
+  defmodule DocStringSteps do
+    use Cucumber.StepDefinition
+
+    step "a doc string:", context do
+      Collector.record({:docstring, context.docstring, context[:docstring_media_type]})
+      :ok
+    end
+  end
+
   defmodule StackTraceSteps do
     use Cucumber.StepDefinition
 
@@ -264,6 +273,39 @@ defmodule Cucumber.CckBehaviorTest do
              |> Enum.all?(fn [b, _step, a] ->
                b == :before and a == :after
              end)
+    end
+  end
+
+  describe "CCK: doc-strings" do
+    test "standard, backtick, and media-typed docstrings all reach the step" do
+      run = run_feature(fixture("doc-strings"), steps: [DocStringSteps])
+
+      assert %{total: 3, passed: 3, failures: 0} = run
+
+      # Scenario order within the nested run depends on the seed, so assert
+      # on the collected set rather than sequence.
+      contents = for {:docstring, content, _media} <- run.events, do: content
+      medias = for {:docstring, _content, media} <- run.events, do: media
+
+      assert Enum.count(contents, &(&1 == "Here is some content\nAnd some more on another line")) ==
+               2
+
+      assert Enum.count(medias, &is_nil/1) == 2
+      assert "application/json" in medias
+      assert Enum.any?(contents, &(&1 =~ ~s("foo": "bar")))
+    end
+  end
+
+  describe "CCK: hooks-skipped (parse-only until skip semantics land)" do
+    test "the feature with scenario descriptions parses and undefined skip steps fail" do
+      # Full skip behavior arrives with issue #21; today this fixture proves
+      # the parser handles its scenario descriptions (issue #17) and the
+      # undefined skip steps fail rather than silently pass.
+      run = run_feature(fixture("hooks-skipped"), steps: [])
+
+      assert run.total == 3
+      assert run.failures == 3
+      assert run.output =~ "No matching step definition found"
     end
   end
 

--- a/test/features/descriptions.feature
+++ b/test/features/descriptions.feature
@@ -1,0 +1,43 @@
+Feature: Descriptions and docstring delimiters
+  Free-form description text can follow any section header.
+  This feature exercises descriptions at every level, plus both
+  docstring delimiters and media type annotations.
+
+  Background:
+    Background sections can carry descriptions too.
+
+    Given a noted base value "carrot"
+
+  Scenario: standard docstring under a described scenario
+    Descriptions under scenarios are plain prose —
+    they should never execute as steps.
+
+    When I note this docstring:
+      """
+      hello from triple quotes
+      """
+    Then the noted docstring is "hello from triple quotes"
+    And the noted docstring has no media type
+
+  Scenario: backtick docstring with a media type
+    Backticks can also be used, like Markdown.
+
+    When I note this docstring:
+      ```json
+      {"vegetable": "carrot"}
+      ```
+    Then the noted docstring contains "vegetable"
+    And the noted docstring media type is "json"
+
+  Scenario Outline: outlines can be described as well
+    The outline description.
+
+    When I note the word <word>
+    Then the noted word is "<word>"
+
+    Examples: some words
+      Examples tables can be described as well.
+
+      | word   |
+      | apple  |
+      | banana |

--- a/test/features/step_definitions/descriptions_steps.exs
+++ b/test/features/step_definitions/descriptions_steps.exs
@@ -1,0 +1,42 @@
+defmodule DescriptionsSteps do
+  use Cucumber.StepDefinition
+  import ExUnit.Assertions
+
+  step "a noted base value {string}", %{args: [value]} do
+    %{base_value: value}
+  end
+
+  step "I note this docstring:", context do
+    assert context.base_value == "carrot"
+    %{noted: context.docstring, noted_media: Map.get(context, :docstring_media_type)}
+  end
+
+  step "the noted docstring is {string}", %{args: [expected]} = context do
+    assert context.noted == expected
+    :ok
+  end
+
+  step "the noted docstring contains {string}", %{args: [expected]} = context do
+    assert context.noted =~ expected
+    :ok
+  end
+
+  step "the noted docstring has no media type", context do
+    assert context.noted_media == nil
+    :ok
+  end
+
+  step "the noted docstring media type is {string}", %{args: [expected]} = context do
+    assert context.noted_media == expected
+    :ok
+  end
+
+  step "I note the word {word}", %{args: [word]} do
+    %{word: word}
+  end
+
+  step "the noted word is {string}", %{args: [expected]} = context do
+    assert context.word == expected
+    :ok
+  end
+end

--- a/test/fixtures/cck/attachments/attachments.feature
+++ b/test/fixtures/cck/attachments/attachments.feature
@@ -1,0 +1,39 @@
+Feature: Attachments
+  It is sometimes useful to take a screenshot while a scenario runs or capture some logs.
+
+  Cucumber lets you `attach` arbitrary files during execution, and you can
+  specify a content type for the contents.
+
+  Formatters can then render these attachments in reports.
+
+  Attachments must have a body and a content type.
+
+  Scenario: Strings can be attached with a media type
+    Beware that some formatters such as the html formatter use the media type
+    to determine how to display an attachment.
+
+    When the string "hello" is attached as "application/octet-stream"
+
+  Scenario: Log text
+    When the string "hello" is logged
+
+  Scenario: Log ANSI coloured text
+    When text with ANSI escapes is logged
+
+  Scenario: Log JSON
+     When the following string is attached as "application/json":
+       ```
+       {"message": "The <b>big</b> question", "foo": "bar"}
+       ```
+
+  Scenario: Byte arrays are base64-encoded regardless of media type
+    When an array with 10 bytes is attached as "text/plain"
+
+  Scenario: Attaching PDFs with a different filename
+    When a PDF document is attached and renamed
+
+  Scenario: Attaching URIs
+    When a link to "https://cucumber.io" is attached
+
+  Scenario: Attaching during a failed step
+    When the string "hello" is attached as "application/octet-stream" before a failure

--- a/test/fixtures/cck/doc-strings/doc-strings.feature
+++ b/test/fixtures/cck/doc-strings/doc-strings.feature
@@ -1,0 +1,31 @@
+Feature: Doc strings
+  Doc strings are a way to supply long, sometimes multi-line, text to a step. They are passed as the last argument
+  to the step definition.
+
+  Scenario: a doc string with standard delimiter
+    Three double quotes above and below are the standard delimiter for doc strings.
+
+    Given a doc string:
+    """
+    Here is some content
+    And some more on another line
+    """
+
+  Scenario: a doc string with backticks delimiter
+    Backticks can also be used, like Markdown, but are less widely supported by editors.
+
+    Given a doc string:
+    ```
+    Here is some content
+    And some more on another line
+    ```
+
+  Scenario: a doc string with media type
+    The media type can be optionally specified too, following the opening delimiter.
+
+    Given a doc string:
+    """application/json
+    {
+      "foo": "bar"
+    }
+    """

--- a/test/fixtures/cck/hooks-skipped/hooks-skipped.feature
+++ b/test/fixtures/cck/hooks-skipped/hooks-skipped.feature
@@ -1,0 +1,26 @@
+Feature: Hooks and skipped
+
+  Before and After hooks behave a little differently when it comes to skipping.
+
+  Scenario: Skip from a step
+
+  Skipping from a step causes all subsequent steps to be skipped, but any After hooks
+  will still be run normally.
+
+    Given a step that skips
+
+  @skip-before
+  Scenario: Skip from a Before hook
+
+  Skipping from a Before hook will cause all subsequent Before hooks and steps to be skipped,
+  but any After hooks will still be run normally.
+
+    Given a normal step
+
+  @skip-after
+  Scenario: Skip from an After hook
+
+  Skipping from a After hook will only mark that hook as skipped. Any subsequent After hooks
+  will still be run normally.
+
+    Given a normal step

--- a/test/gherkin_descriptions_test.exs
+++ b/test/gherkin_descriptions_test.exs
@@ -1,0 +1,318 @@
+defmodule GherkinDescriptionsTest do
+  use ExUnit.Case, async: true
+
+  alias Gherkin.Parser
+
+  describe "feature descriptions" do
+    test "feature description is captured" do
+      feature =
+        Parser.parse("""
+        Feature: Described
+          This is the first line.
+          This is the second line.
+
+          Scenario: one
+            Given a step
+        """)
+
+      assert feature.description == "This is the first line.\nThis is the second line."
+    end
+
+    test "interior blank lines are preserved, leading/trailing blanks dropped" do
+      feature =
+        Parser.parse("""
+        Feature: Described
+
+          Paragraph one.
+
+          Paragraph two.
+
+          Scenario: one
+            Given a step
+        """)
+
+      assert feature.description == "Paragraph one.\n\nParagraph two."
+    end
+
+    test "step-keyword-like lines and bullets remain feature description" do
+      # At feature level there are no steps, so * bullets and lines starting
+      # with Given/When/Then are still description (CCK minimal.feature shape).
+      feature =
+        Parser.parse("""
+        Feature: minimal
+
+          Cucumber doesn't execute this markdown, but it renders it.
+
+          * This is
+          * a bullet
+          * list
+
+          Given the chance, this line also stays description.
+
+          Scenario: cukes
+            Given a step
+        """)
+
+      assert feature.description =~ "* This is\n* a bullet\n* list"
+      assert feature.description =~ "Given the chance"
+      assert [%Gherkin.Scenario{steps: [step]}] = feature.scenarios
+      assert step.text == "a step"
+    end
+
+    test "comment lines are excluded from descriptions" do
+      feature =
+        Parser.parse("""
+        Feature: Described
+          Real description.
+          # this is a comment, not description
+
+          Scenario: one
+            Given a step
+        """)
+
+      assert feature.description == "Real description."
+    end
+
+    test "a feature with a description and no scenarios parses (no hang at EOF)" do
+      feature = Parser.parse("Feature: lonely\n  Just a description, nothing else.")
+
+      assert feature.description == "Just a description, nothing else."
+      assert feature.scenarios == []
+    end
+  end
+
+  describe "section descriptions" do
+    test "background description is captured and steps still run" do
+      feature =
+        Parser.parse("""
+        Feature: F
+
+          Background:
+            Why this background exists,
+            in two lines.
+
+            Given some setup
+
+          Scenario: one
+            Given a step
+        """)
+
+      assert feature.background.description == "Why this background exists,\nin two lines."
+      assert [%Gherkin.Step{text: "some setup"}] = feature.background.steps
+    end
+
+    test "scenario description is captured; description never becomes steps" do
+      feature =
+        Parser.parse("""
+        Feature: F
+
+          Scenario: described
+            Beware that some formatters use the media type
+            to determine how to display things.
+
+            Given a real step
+            And another real step
+        """)
+
+      [scenario] = feature.scenarios
+
+      assert scenario.description ==
+               "Beware that some formatters use the media type\nto determine how to display things."
+
+      assert Enum.map(scenario.steps, & &1.text) == ["a real step", "another real step"]
+    end
+
+    test "a description line containing a step keyword mid-sentence stays description" do
+      feature =
+        Parser.parse("""
+        Feature: F
+
+          Scenario: described
+            You are Given a chance to read this prose.
+
+            Given a real step
+        """)
+
+      [scenario] = feature.scenarios
+      assert scenario.description == "You are Given a chance to read this prose."
+      assert [%Gherkin.Step{text: "a real step"}] = scenario.steps
+    end
+
+    test "a line starting with a step-keyword-prefixed word stays description" do
+      # "Givenness" starts with "Given" but is not followed by whitespace,
+      # so it is not a step.
+      feature =
+        Parser.parse("""
+        Feature: F
+
+          Scenario: described
+            Givenness is not a step keyword.
+
+            Given a real step
+        """)
+
+      [scenario] = feature.scenarios
+      assert scenario.description == "Givenness is not a step keyword."
+      assert [%Gherkin.Step{text: "a real step"}] = scenario.steps
+    end
+
+    test "scenario outline and examples descriptions are captured" do
+      feature =
+        Parser.parse("""
+        Feature: F
+
+          Scenario Outline: described outline
+            The outline description.
+
+            Given <thing>
+
+            Examples: described examples
+              The examples description.
+
+              | thing |
+              | a     |
+        """)
+
+      [outline] = feature.scenarios
+      assert outline.description == "The outline description."
+      assert [examples] = outline.examples
+      assert examples.description == "The examples description."
+      assert examples.table_header == ["thing"]
+      assert examples.table_body == [["a"]]
+    end
+
+    test "scenarios without descriptions get an empty string" do
+      feature =
+        Parser.parse("""
+        Feature: F
+          Scenario: plain
+            Given a step
+        """)
+
+      [scenario] = feature.scenarios
+      assert scenario.description == ""
+      assert feature.description == ""
+    end
+
+    test "previously-failing CCK fixtures with scenario descriptions now parse" do
+      for fixture <- ["attachments/attachments.feature", "hooks-skipped/hooks-skipped.feature"] do
+        feature =
+          Path.join("test/fixtures/cck", fixture)
+          |> File.read!()
+          |> Parser.parse()
+
+        assert feature.scenarios != [], "#{fixture} parsed no scenarios"
+      end
+    end
+  end
+
+  describe "docstring delimiters and media types" do
+    test "backtick docstrings deliver the same content as triple quotes" do
+      standard =
+        Parser.parse("""
+        Feature: F
+          Scenario: s
+            Given a doc string:
+              \"\"\"
+              Here is some content
+              And some more on another line
+              \"\"\"
+        """)
+
+      backtick =
+        Parser.parse("""
+        Feature: F
+          Scenario: s
+            Given a doc string:
+              ```
+              Here is some content
+              And some more on another line
+              ```
+        """)
+
+      [%{steps: [standard_step]}] = standard.scenarios
+      [%{steps: [backtick_step]}] = backtick.scenarios
+
+      assert standard_step.docstring == "Here is some content\nAnd some more on another line"
+      assert backtick_step.docstring == standard_step.docstring
+    end
+
+    test "media type is captured for both delimiters and nil when absent" do
+      feature =
+        Parser.parse("""
+        Feature: F
+          Scenario: s
+            Given a json doc string:
+              \"\"\"application/json
+              {"foo": "bar"}
+              \"\"\"
+            And a ruby doc string:
+              ```ruby
+              puts "hi"
+              ```
+            And a plain doc string:
+              \"\"\"
+              plain
+              \"\"\"
+        """)
+
+      [%{steps: [json_step, ruby_step, plain_step]}] = feature.scenarios
+
+      assert json_step.docstring_media_type == "application/json"
+      assert json_step.docstring == ~s({"foo": "bar"})
+      assert ruby_step.docstring_media_type == "ruby"
+      assert plain_step.docstring_media_type == nil
+    end
+
+    test "each delimiter style is literal content inside the other" do
+      feature =
+        Parser.parse("""
+        Feature: F
+          Scenario: s
+            Given a doc string:
+              \"\"\"
+              what is `backtick` ```
+              \"\"\"
+            And another doc string:
+              ```
+              triple quote: \"\"\"
+              ```
+        """)
+
+      [%{steps: [first, second]}] = feature.scenarios
+      assert first.docstring == "what is `backtick` ```"
+      assert second.docstring == ~s(triple quote: """)
+    end
+
+    test "backtick docstrings dedent the same way as standard ones" do
+      feature =
+        Parser.parse("""
+        Feature: F
+          Scenario: s
+            Given a doc string:
+              ```
+              first
+                indented relative
+              first again
+              ```
+        """)
+
+      [%{steps: [step]}] = feature.scenarios
+      assert step.docstring == "first\n  indented relative\nfirst again"
+    end
+
+    test "the CCK doc-strings fixture parses with all three scenarios" do
+      feature =
+        "test/fixtures/cck/doc-strings/doc-strings.feature"
+        |> File.read!()
+        |> Parser.parse()
+
+      assert length(feature.scenarios) == 3
+
+      [standard, backtick, media] = feature.scenarios
+      assert standard.steps |> hd() |> Map.fetch!(:docstring) =~ "Here is some content"
+      assert backtick.steps |> hd() |> Map.fetch!(:docstring) =~ "Here is some content"
+      assert media.steps |> hd() |> Map.fetch!(:docstring_media_type) == "application/json"
+    end
+  end
+end

--- a/test/gherkin_test.exs
+++ b/test/gherkin_test.exs
@@ -486,6 +486,7 @@ defmodule Gherkin.ParserTest do
         "test/features/advanced_features.feature" => 2,
         "test/features/async_example.feature" => 2,
         "test/features/database_example.feature" => 2,
+        "test/features/descriptions.feature" => 3,
         "test/features/error_reporting.feature" => 2,
         "test/features/feature_level_tags.feature" => 2,
         "test/features/hook_execution_order.feature" => 1,
@@ -496,6 +497,11 @@ defmodule Gherkin.ParserTest do
         "test/features/simple.feature" => 1,
         "test/features/tagged.feature" => 4
       }
+
+      # Every live feature file must have an entry, so a new file can't
+      # silently skip this check.
+      assert Path.wildcard("test/features/**/*.feature") |> Enum.sort() ==
+               expected_counts |> Map.keys() |> Enum.sort()
 
       for {file, expected_count} <- expected_counts do
         content = File.read!(file)


### PR DESCRIPTION
Closes #17. Closes #18.

Roadmap PR 1 (after the harness in #30). Three parser problems fixed, all standard Gherkin:

## Descriptions under any section header (#17)

Free-form description text after `Background:`, `Scenario:`, `Scenario Outline:`, or `Examples:` previously raised a parse error that made the entire feature file unusable — two CCK samples failed to parse solely because of this. Description regions now parse at every level and are **captured** into new `description` fields (default `""`) on `Background`, `Scenario`, `ScenarioOutline`, and `Examples`; the feature-level description (previously parsed but discarded) lands on `Feature.description`. Capturing now rather than discarding is groundwork for the Cucumber Messages `gherkinDocument` (#28). Descriptions never affect execution.

Keyword-detection subtleties covered by tests: a step keyword requires trailing whitespace (so "Givenness …" stays description), step-keyword lines *inside* a scenario terminate the description (they're steps), but at feature level `* bullets` and "Given …" lines remain description (there are no steps there — the CCK `minimal.feature` shape).

## Backtick docstrings + media types (#18)

```` ``` ```` now works as a docstring delimiter alongside `"""`. Each delimiter has its own combinator, so the closing delimiter must match the opening one and the other style is plain content. An optional media type after the opening delimiter (e.g. ```` ```json ````) is captured as `Step.docstring_media_type` and exposed as `context.docstring_media_type`. `context.docstring` stays a plain string — no breaking change for existing step definitions.

## Latent parser hang fixed

The description combinator could succeed on a **zero-width match** at end of input, and NimbleParsec's `repeat` does not guard against no-progress loops — so a feature ending in description text, or a scenario with no steps at EOF, hung the parser forever (60s test timeout caught it via the CCK `empty` fixture). Description lines now must consume at least one byte. This bug predates this PR in shape; a regression test covers it.

## Tests

- `test/gherkin_descriptions_test.exs`: 14 parser unit tests covering every behavior on the checklist (multi-line joining, interior blanks, comments excluded, keyword edge cases, both delimiters, media types, cross-delimiter content, dedenting, CCK fixtures).
- Behavior tests: described scenarios execute normally; the CCK `doc-strings` sample runs end-to-end (3 scenarios — standard, backtick, media type); `hooks-skipped` vendored as parse-proof (full skip semantics arrive with #21).
- Live dogfood: `test/features/descriptions.feature` exercises descriptions at every level plus both docstring forms on every `mix test`.
- The scenario-count test now asserts its map covers **all** live feature files, so additions can't silently skip it.

`mix precommit` green: 239 tests (was 215).