### PR TITLE
Ambiguous step detection, feature-file stack traces, single matching path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Bug Fixes
 
+- **Ambiguous steps are now detected** (#20). A step whose text matches more than one step definition previously executed an arbitrary first match and passed silently. Step resolution now collects all matches and raises `Cucumber.AmbiguousStepError` listing every matching pattern with its definition site (`file:line`), failing the scenario. Ambiguity is detected per step text at runtime; the discovery-time exact-duplicate check is unchanged.
+
+### Improvements
+
+- **Step failure stack traces point at the feature file** (#22). The first stack frame of a failing (or undefined, or ambiguous) step now references the feature file and the failing step's line; the step definition's own frame follows, and internal `Cucumber.Runtime` frames are filtered from the trace.
+- **Single step-matching path.** Step dispatch now happens entirely in `Cucumber.Runtime` via the step registry; the generated per-module `step/2` dispatcher (which re-ran its own first-match loop) has been removed. **Breaking:** code calling `MySteps.step(context, text)` directly should go through `Cucumber.Runtime.execute_step/3` instead.
+- **Step registry keys are now `{:expression, source}` tuples** (was bare pattern strings), making room for regex step definitions (#24). **Breaking** for code reading `DiscoveryResult.step_registry` directly.
+- Generated feature modules no longer embed a full copy of the step registry and hook list in their AST; both now live in `:persistent_term` under per-compilation keys (also future-proof for `mix test.watch` staleness).
+
 - **Descriptions under any section header now parse** (#17). Standard Gherkin allows free-form description text after `Background:`, `Scenario:`, `Scenario Outline:`, and `Examples:` headers; previously such lines caused a parse error that made the whole feature file unusable. Descriptions are now captured on the corresponding structs (`description` field, default `""`), and the feature-level description — previously discarded — is captured on `Gherkin.Feature.description`. Descriptions never affect execution.
 - **Parser no longer hangs on a feature ending in a description.** A latent zero-width repeat in the description combinator could loop forever at end of input (e.g. a feature whose last line is description text, or a scenario with no steps at EOF).
 

--- a/lib/cucumber/ambiguous_step_error.ex
+++ b/lib/cucumber/ambiguous_step_error.ex
@@ -1,0 +1,72 @@
+defmodule Cucumber.AmbiguousStepError do
+  @moduledoc """
+  Exception raised when a step's text matches more than one step definition.
+
+  Cucumber cannot know which definition the author intended, so the scenario
+  fails with this error listing every matching pattern and where each is
+  defined. Ambiguity is a property of a concrete step text at runtime — two
+  patterns may overlap for one input but not another — so this is detected
+  during step resolution, not at load time.
+
+  This is a distinct exception type (rather than a `Cucumber.StepError`) so
+  downstream features can treat it specially — e.g. retry logic must never
+  retry an ambiguous step, and Cucumber Messages report it as AMBIGUOUS
+  rather than FAILED.
+  """
+
+  defexception [
+    :message,
+    :step,
+    :matches,
+    :feature_file,
+    :scenario_name
+  ]
+
+  @type match :: {pattern_source :: String.t(), module(), metadata :: map()}
+
+  @type t :: %__MODULE__{
+          message: String.t(),
+          step: Gherkin.Step.t() | nil,
+          matches: [match()],
+          feature_file: String.t() | nil,
+          scenario_name: String.t() | nil
+        }
+
+  @doc """
+  Builds the error for a step that matched several definitions.
+
+  `matches` is a list of `{pattern_source, module, metadata}` tuples, where
+  metadata carries the definition's `:file` and `:line`.
+  """
+  @spec new(Gherkin.Step.t(), [match()], String.t(), String.t()) :: t()
+  def new(step, matches, feature_file, scenario_name) do
+    location = "#{feature_file}:#{step.line + 1}"
+
+    listing =
+      Enum.map_join(matches, "\n", fn {pattern, module, metadata} ->
+        "  * \"#{pattern}\" (#{inspect(module)} at #{Path.relative_to_cwd(metadata.file)}:#{metadata.line})"
+      end)
+
+    message = """
+    Ambiguous step:
+
+      #{step.keyword} #{step.text}
+
+    in scenario "#{scenario_name}" (#{location})
+
+    matches #{length(matches)} step definitions:
+
+    #{listing}
+
+    Remove or rephrase one of these definitions so only one matches.
+    """
+
+    %__MODULE__{
+      message: message,
+      step: step,
+      matches: matches,
+      feature_file: feature_file,
+      scenario_name: scenario_name
+    }
+  end
+end

--- a/lib/cucumber/compiler.ex
+++ b/lib/cucumber/compiler.ex
@@ -53,6 +53,14 @@ defmodule Cucumber.Compiler do
     # Collect all hooks
     all_hooks = Cucumber.Hooks.collect_hooks(hook_modules)
 
+    # The registry and hook list live in :persistent_term rather than being
+    # Macro.escape'd into every generated module (which bloats each module's
+    # AST with a full copy). Keys are unique per compilation, so repeated
+    # compiles (mix test.watch, test harnesses) can't see stale data.
+    runtime_key = {Cucumber, :runtime_data, :erlang.unique_integer([:positive])}
+
+    :persistent_term.put(runtime_key, %{step_registry: step_registry, hooks: all_hooks})
+
     # Generate test module AST
     ast =
       quote do
@@ -70,13 +78,18 @@ defmodule Cucumber.Compiler do
             end
           )
 
-          # Store the step registry for runtime access
+          # Runtime data accessors (registry and hooks live in :persistent_term)
           def __step_registry__ do
-            unquote(Macro.escape(Map.new(step_registry)))
+            :persistent_term.get(unquote(Macro.escape(runtime_key))).step_registry
+          end
+
+          @doc false
+          def __cucumber_feature_hooks__ do
+            :persistent_term.get(unquote(Macro.escape(runtime_key))).hooks
           end
 
           # If there's a background or feature-level tags, create setup block
-          unquote(generate_setup(feature.background, step_registry, feature, all_hooks))
+          unquote(generate_setup(feature.background, step_registry, feature))
 
           # Expand scenario outlines and generate test for each scenario
           unquote_splicing(
@@ -133,22 +146,22 @@ defmodule Cucumber.Compiler do
     :"feature_#{tag_name}"
   end
 
-  defp generate_setup(nil, _step_registry, feature, all_hooks) do
+  defp generate_setup(nil, _step_registry, feature) do
     # Always generate setup to run hooks for all scenarios
-    build_setup_block([], feature, all_hooks)
+    build_setup_block([], feature)
   end
 
-  defp generate_setup(background, step_registry, feature, all_hooks) do
+  defp generate_setup(background, step_registry, feature) do
     background_steps =
       for step <- background.steps do
         generate_step_execution(step, step_registry)
       end
 
-    build_setup_block(background_steps, feature, all_hooks)
+    build_setup_block(background_steps, feature)
   end
 
   # Shared helper to build the setup block with hooks and optional background steps
-  defp build_setup_block(background_steps, feature, all_hooks) do
+  defp build_setup_block(background_steps, feature) do
     async = "async" in feature.tags
 
     quote do
@@ -192,7 +205,7 @@ defmodule Cucumber.Compiler do
         # Run ALL matching hooks (global + feature + scenario tags)
         result =
           Cucumber.Hooks.run_before_hooks(
-            unquote(Macro.escape(all_hooks)),
+            __cucumber_feature_hooks__(),
             context,
             all_tags
           )
@@ -203,12 +216,10 @@ defmodule Cucumber.Compiler do
             unquote_splicing(background_steps)
 
             # Register cleanup for after hooks
+            hooks = __cucumber_feature_hooks__()
+
             on_exit(fn ->
-              Cucumber.Hooks.run_after_hooks(
-                unquote(Macro.escape(all_hooks)),
-                context,
-                all_tags
-              )
+              Cucumber.Hooks.run_after_hooks(hooks, context, all_tags)
             end)
 
             {:ok, context}

--- a/lib/cucumber/discovery.ex
+++ b/lib/cucumber/discovery.ex
@@ -24,10 +24,17 @@ defmodule Cucumber.Discovery do
     @moduledoc "Result struct returned by `Cucumber.Discovery.discover/1`."
     defstruct features: [], step_modules: [], step_registry: %{}, hook_modules: []
 
+    @typedoc """
+    Registry keys identify the pattern kind and source — `{:expression, source}`
+    for cucumber expressions (regex patterns are planned to join as
+    `{:regex, source}`).
+    """
+    @type registry_key :: {:expression, String.t()}
+
     @type t :: %__MODULE__{
             features: [Gherkin.Feature.t()],
             step_modules: [module()],
-            step_registry: %{String.t() => {module(), map()}},
+            step_registry: %{registry_key() => {module(), map()}},
             hook_modules: [module()]
           }
   end
@@ -129,9 +136,12 @@ defmodule Cucumber.Discovery do
 
   defp add_module_steps_to_registry(registry, module, steps) do
     Enum.reduce(steps, registry, fn {pattern, metadata}, acc ->
-      # Check for duplicates using pattern as key
-      if Map.has_key?(acc, pattern) do
-        {existing_module, existing_meta} = acc[pattern]
+      key = {:expression, pattern}
+
+      # Check for exact duplicates at load time (overlapping-but-different
+      # patterns are detected per step text at runtime as ambiguity)
+      if Map.has_key?(acc, key) do
+        {existing_module, existing_meta} = acc[key]
 
         raise """
         Duplicate step definition: '#{pattern}'
@@ -145,7 +155,7 @@ defmodule Cucumber.Discovery do
       end
 
       # Store with pattern as key (compile at runtime)
-      Map.put(acc, pattern, {module, metadata})
+      Map.put(acc, key, {module, metadata})
     end)
   end
 

--- a/lib/cucumber/runtime.ex
+++ b/lib/cucumber/runtime.ex
@@ -31,13 +31,13 @@ defmodule Cucumber.Runtime do
 
     # Find matching step definition
     case find_step_definition(step.text, step_registry) do
-      {:ok, {module, _metadata}, args, pattern_text} ->
+      {:ok, {module, metadata}, args, pattern_text} ->
         # Prepare context with step arguments
         context = prepare_context(context, args, step)
 
         # Execute the step
         try do
-          result = module.step(context, step.text)
+          result = apply(module, metadata.function, [context])
           process_step_result(result, context)
         rescue
           e ->
@@ -57,8 +57,19 @@ defmodule Cucumber.Runtime do
                 format_step_history_with_status(step_history, step, context)
               )
 
-            reraise enhanced_error, __STACKTRACE__
+            reraise enhanced_error, scenario_stacktrace(context, step, __STACKTRACE__)
         end
+
+      {:ambiguous, matches} ->
+        feature_file = Map.get(context, :feature_file, "unknown")
+        scenario_name = Map.get(context, :scenario_name, "unknown scenario")
+
+        listed =
+          for {pattern_text, {module, metadata}, _args} <- matches,
+              do: {pattern_text, module, metadata}
+
+        error = Cucumber.AmbiguousStepError.new(step, listed, feature_file, scenario_name)
+        :erlang.raise(:error, error, scenario_stacktrace(context, step, current_stacktrace()))
 
       :error ->
         # Extract context info for better error
@@ -67,26 +78,62 @@ defmodule Cucumber.Runtime do
         step_history = Map.get(context, :step_history, [])
 
         # Use the enhanced error module
-        raise Cucumber.StepError.missing_step_definition(
-                step,
-                feature_file,
-                scenario_name,
-                format_step_history_with_status(step_history, step, context)
-              )
+        error =
+          Cucumber.StepError.missing_step_definition(
+            step,
+            feature_file,
+            scenario_name,
+            format_step_history_with_status(step_history, step, context)
+          )
+
+        :erlang.raise(:error, error, scenario_stacktrace(context, step, current_stacktrace()))
     end
   end
 
   defp find_step_definition(step_text, step_registry) do
-    # Try to match against each registered pattern
-    Enum.find_value(step_registry, :error, fn {pattern_text, definition} ->
-      # Compile pattern on the fly
-      compiled_pattern = Expression.compile(pattern_text)
+    matches =
+      Enum.flat_map(step_registry, fn {{:expression, pattern_text}, definition} ->
+        # Compile pattern on the fly (cached via :persistent_term)
+        compiled_pattern = Expression.compile(pattern_text)
 
-      case Expression.match(step_text, compiled_pattern) do
-        {:match, args} -> {:ok, definition, args, pattern_text}
-        :no_match -> nil
-      end
-    end)
+        case Expression.match(step_text, compiled_pattern) do
+          {:match, args} -> [{pattern_text, definition, args}]
+          :no_match -> []
+        end
+      end)
+
+    case matches do
+      [] ->
+        :error
+
+      [{pattern_text, definition, args}] ->
+        {:ok, definition, args, pattern_text}
+
+      multiple ->
+        # Stable listing order regardless of map iteration order
+        {:ambiguous, Enum.sort_by(multiple, fn {pattern_text, _, _} -> pattern_text end)}
+    end
+  end
+
+  # Builds the stacktrace reported for a step failure: the first frame points
+  # at the failing step's line in the feature file, followed by the original
+  # trace (which leads with the step definition's own frame) minus this
+  # module's internal frames.
+  defp scenario_stacktrace(context, step, stacktrace) do
+    test_module = Map.get(context, :module, Cucumber.Scenario)
+
+    feature_file = Map.get(context, :feature_file, "unknown")
+
+    feature_frame =
+      {test_module, :scenario, 1, [file: String.to_charlist(feature_file), line: step.line + 1]}
+
+    [feature_frame | Enum.reject(stacktrace, &match?({__MODULE__, _, _, _}, &1))]
+  end
+
+  defp current_stacktrace do
+    {:current_stacktrace, trace} = Process.info(self(), :current_stacktrace)
+    # Drop Process.info/2 and this function's own frames
+    Enum.reject(trace, &match?({Process, _, _, _}, &1))
   end
 
   defp prepare_context(context, args, step) do

--- a/lib/cucumber/step_definition.ex
+++ b/lib/cucumber/step_definition.ex
@@ -55,49 +55,14 @@ defmodule Cucumber.StepDefinition do
       Module.get_attribute(env.module, :cucumber_steps, [])
       |> Enum.reverse()
 
-    # Generate the step/2 function body
-    match_clauses =
-      for {pattern, metadata} <- steps do
-        quote do
-          {unquote(pattern), unquote(metadata.function)}
-        end
-      end
-
-    step_function =
-      quote do
-        def step(context, step_text) do
-          # List of patterns and their functions
-          patterns = unquote(match_clauses)
-
-          # Find the first matching pattern
-          result =
-            Enum.find_value(patterns, fn {pattern, fun_name} ->
-              case Cucumber.Expression.match(step_text, Cucumber.Expression.compile(pattern)) do
-                {:match, args} ->
-                  # Add args to context and call the step function
-                  context_with_args = Map.put(context, :args, args)
-                  {:ok, apply(__MODULE__, fun_name, [context_with_args])}
-
-                :no_match ->
-                  nil
-              end
-            end)
-
-          case result do
-            {:ok, value} -> value
-            nil -> raise "No step definition found for: #{step_text}"
-          end
-        end
-      end
-
+    # Note: step matching and dispatch happen in Cucumber.Runtime via the
+    # step registry — there is deliberately no per-module dispatcher, so
+    # matching semantics (including ambiguity detection) live in one place.
     quote do
       # Make steps available for discovery
       def __cucumber_steps__ do
         unquote(Macro.escape(steps))
       end
-
-      # Define the step/2 function
-      unquote(step_function)
     end
   end
 end

--- a/test/cucumber/behavior/ambiguity_and_stacktrace_test.exs
+++ b/test/cucumber/behavior/ambiguity_and_stacktrace_test.exs
@@ -1,0 +1,171 @@
+defmodule Cucumber.AmbiguityAndStacktraceTest do
+  @moduledoc """
+  Behavior tests for ambiguous step detection (#20) and feature-file stack
+  frames (#22).
+  """
+
+  use Cucumber.BehaviorCase
+
+  alias Cucumber.BehaviorCase.Collector
+
+  defmodule AmbiguousSteps do
+    use Cucumber.StepDefinition
+
+    step "a step with multiple definitions", _context do
+      Collector.record(:literal_definition)
+      :ok
+    end
+
+    step "a {word} with multiple definitions", _context do
+      Collector.record(:parameterized_definition)
+      :ok
+    end
+
+    step "a step after the ambiguous one", _context do
+      Collector.record(:after_ambiguous)
+      :ok
+    end
+
+    step "an unambiguous walrus with multiple definitions", _context do
+      Collector.record(:unambiguous)
+      :ok
+    end
+  end
+
+  defmodule FailingSteps do
+    use Cucumber.StepDefinition
+
+    step "a passing step", _context do
+      :ok
+    end
+
+    step "a step that raises", _context do
+      raise "kaboom"
+    end
+  end
+
+  describe "ambiguous step detection (CCK: ambiguous)" do
+    test "a step matching two definitions fails with both patterns and their locations" do
+      run =
+        run_feature(
+          File.read!("test/fixtures/cck/ambiguous/ambiguous.feature"),
+          steps: [AmbiguousSteps]
+        )
+
+      assert %{total: 1, passed: 0, failures: 1} = run
+      assert run.output =~ "Cucumber.AmbiguousStepError"
+      assert run.output =~ "matches 2 step definitions"
+      assert run.output =~ ~s("a step with multiple definitions")
+      assert run.output =~ ~s("a {word} with multiple definitions")
+      # Both definition sites are listed with file:line
+      assert run.output =~ ~r/ambiguity_and_stacktrace_test\.exs:\d+/
+      # Neither definition actually executed
+      assert run.events == []
+    end
+
+    test "overlapping patterns are not ambiguous for a text only one of them matches" do
+      # "an unambiguous walrus with multiple definitions" is matched by the
+      # literal definition; "a {word} with multiple definitions" does not
+      # match it (different leading article), so there is no false positive.
+      run =
+        run_feature(
+          """
+          Feature: not ambiguous
+            Scenario: only one matches
+              Given an unambiguous walrus with multiple definitions
+          """,
+          steps: [AmbiguousSteps]
+        )
+
+      assert %{total: 1, passed: 1, failures: 0} = run
+      assert run.events == [:unambiguous]
+    end
+
+    test "steps after an ambiguous step do not execute" do
+      run =
+        run_feature(
+          """
+          Feature: ambiguous mid-scenario
+            Scenario: stops at ambiguity
+              Given a step with multiple definitions
+              And a step after the ambiguous one
+          """,
+          steps: [AmbiguousSteps]
+        )
+
+      assert run.failures == 1
+      refute :after_ambiguous in run.events
+    end
+
+    test "an ambiguous background step fails every scenario in the feature" do
+      run =
+        run_feature(
+          """
+          Feature: ambiguous background
+            Background:
+              Given a step with multiple definitions
+
+            Scenario: first
+              Given a step after the ambiguous one
+
+            Scenario: second
+              Given a step after the ambiguous one
+          """,
+          steps: [AmbiguousSteps]
+        )
+
+      assert run.total == 2
+      assert run.passed == 0
+      assert run.events == []
+    end
+  end
+
+  describe "stack traces point at the feature file (#22)" do
+    test "a failing step's first stack frame is the feature file at the step's line" do
+      run =
+        run_feature(
+          """
+          Feature: stack frames
+            Scenario: failing
+              Given a passing step
+              And a step that raises
+          """,
+          steps: [FailingSteps],
+          file: "test/fixtures/generated/stack_frames.feature"
+        )
+
+      assert run.failures == 1
+
+      stacktrace_section = run.output |> String.split("stacktrace:") |> List.last()
+      [first_frame, second_frame | _] = stacktrace_section |> String.split("\n", trim: true)
+
+      # First frame: the failing step's line in the feature file
+      assert first_frame =~ "test/fixtures/generated/stack_frames.feature:4"
+      # Second frame: the step definition that raised
+      assert second_frame =~ "ambiguity_and_stacktrace_test.exs"
+      # Internal runtime frames are filtered out
+      refute run.output =~ "lib/cucumber/runtime.ex"
+    end
+
+    test "a missing step's stack trace also leads with the feature file" do
+      run =
+        run_feature(
+          """
+          Feature: missing step frames
+            Scenario: undefined
+              Given a step nobody defined
+          """,
+          steps: [FailingSteps],
+          file: "test/fixtures/generated/missing_frames.feature"
+        )
+
+      assert run.failures == 1
+
+      stacktrace_section = run.output |> String.split("stacktrace:") |> List.last()
+      [first_frame | _] = stacktrace_section |> String.split("\n", trim: true)
+
+      assert first_frame =~ "test/fixtures/generated/missing_frames.feature:3"
+      refute run.output =~ "lib/cucumber/runtime.ex"
+    end
+  end
+end

--- a/test/cucumber/behavior/cck_behavior_test.exs
+++ b/test/cucumber/behavior/cck_behavior_test.exs
@@ -310,11 +310,20 @@ defmodule Cucumber.CckBehaviorTest do
   end
 
   describe "CCK: stack-traces" do
-    test "a step that throws fails the scenario with the exception message" do
-      run = run_feature(fixture("stack-traces"), steps: [StackTraceSteps])
+    test "a step that throws fails with the exception message and a feature-file stack frame" do
+      run =
+        run_feature(fixture("stack-traces"),
+          steps: [StackTraceSteps],
+          file: "test/fixtures/cck/stack-traces/stack-traces.feature"
+        )
 
       assert %{total: 1, passed: 0, failures: 1} = run
       assert run.output =~ "BOOM"
+
+      # CCK: the first line of the stack trace references the feature file
+      stacktrace_section = run.output |> String.split("stacktrace:") |> List.last()
+      [first_frame | _] = String.split(stacktrace_section, "\n", trim: true)
+      assert first_frame =~ "stack-traces.feature:10"
     end
   end
 

--- a/test/cucumber/discovery_test.exs
+++ b/test/cucumber/discovery_test.exs
@@ -58,7 +58,7 @@ defmodule Cucumber.DiscoveryTest do
 
         assert %Discovery.DiscoveryResult{} = result
         assert length(result.step_modules) == 1
-        assert Map.has_key?(result.step_registry, "I am a valid step")
+        assert Map.has_key?(result.step_registry, {:expression, "I am a valid step"})
       after
         File.rm_rf(temp_dir)
       end
@@ -137,8 +137,8 @@ defmodule Cucumber.DiscoveryTest do
       try do
         result = Discovery.discover(steps: [Path.join(step_dir, "*.exs")])
 
-        assert Map.has_key?(result.step_registry, "I have {int} items")
-        {module, metadata} = result.step_registry["I have {int} items"]
+        assert Map.has_key?(result.step_registry, {:expression, "I have {int} items"})
+        {module, metadata} = result.step_registry[{:expression, "I have {int} items"}]
         assert is_atom(module)
         assert is_map(metadata)
         assert Map.has_key?(metadata, :line)
@@ -179,8 +179,8 @@ defmodule Cucumber.DiscoveryTest do
         result = Discovery.discover(steps: [Path.join(step_dir, "*.exs")])
 
         assert length(result.step_modules) == 2
-        assert Map.has_key?(result.step_registry, "step from first module")
-        assert Map.has_key?(result.step_registry, "step from second module")
+        assert Map.has_key?(result.step_registry, {:expression, "step from first module"})
+        assert Map.has_key?(result.step_registry, {:expression, "step from second module"})
       after
         File.rm_rf(temp_dir)
       end

--- a/test/cucumber/runtime_error_test.exs
+++ b/test/cucumber/runtime_error_test.exs
@@ -4,13 +4,20 @@ defmodule Cucumber.RuntimeErrorTest do
   alias Cucumber.Runtime
   alias Gherkin.Step
 
+  defmodule FailingSteps do
+    use Cucumber.StepDefinition
+
+    step "I fail with an error", _context do
+      raise "deliberate failure"
+    end
+  end
+
   describe "error formatting in execute_step/3" do
     setup do
-      # Create a simple step registry for testing
-      step_registry = %{
-        "I fail with an error" => {FailingStepModule, %{}},
-        "I fail with {string}" => {FailingStepModule, %{}}
-      }
+      step_registry =
+        for {pattern, metadata} <- FailingSteps.__cucumber_steps__(), into: %{} do
+          {{:expression, pattern}, {FailingSteps, metadata}}
+        end
 
       {:ok, step_registry: step_registry}
     end
@@ -48,43 +55,46 @@ defmodule Cucumber.RuntimeErrorTest do
         step_history: []
       }
 
-      # This will fail because FailingStepModule doesn't exist
-      # but we're testing the error handling
-      assert_raise Cucumber.StepError, fn ->
-        Runtime.execute_step(context, step, step_registry)
-      end
+      error =
+        assert_raise Cucumber.StepError, fn ->
+          Runtime.execute_step(context, step, step_registry)
+        end
+
+      assert error.message =~ "deliberate failure"
     end
   end
 
   describe "PhoenixTest error formatting" do
-    test "formats HTML elements with proper indentation" do
-      # Create a mock module that can handle our test step
-      defmodule MockPhoenixTestStep do
-        def step(_context, _text) do
-          # Simulate a PhoenixTest error
-          raise """
-          Could not find any elements with selector "button" and text "Submit"
+    defmodule MockPhoenixTestSteps do
+      use Cucumber.StepDefinition
 
-          Found these elements matching the selector "button":
+      step "I click the submit button", _context do
+        # Simulate a PhoenixTest error
+        raise """
+        Could not find any elements with selector "button" and text "Submit"
 
-          <button class="btn btn-primary">
-            Save Draft
-          </button>
+        Found these elements matching the selector "button":
 
-          <button class="btn btn-secondary">
-            Cancel
-          </button>
+        <button class="btn btn-primary">
+          Save Draft
+        </button>
 
-          <button type="submit" disabled>
-            Submit (disabled)
-          </button>
-          """
-        end
+        <button class="btn btn-secondary">
+          Cancel
+        </button>
+
+        <button type="submit" disabled>
+          Submit (disabled)
+        </button>
+        """
       end
+    end
 
-      step_registry = %{
-        "I click the submit button" => {MockPhoenixTestStep, %{}}
-      }
+    test "formats HTML elements with proper indentation" do
+      step_registry =
+        for {pattern, metadata} <- MockPhoenixTestSteps.__cucumber_steps__(), into: %{} do
+          {{:expression, pattern}, {MockPhoenixTestSteps, metadata}}
+        end
 
       step = %Step{
         keyword: "When",

--- a/test/cucumber/runtime_test.exs
+++ b/test/cucumber/runtime_test.exs
@@ -52,18 +52,10 @@ defmodule Cucumber.RuntimeTest do
   end
 
   setup do
-    step_registry = %{
-      "I return ok" => {TestSteps, %{}},
-      "I return a map with {string}" => {TestSteps, %{}},
-      "I return a keyword list" => {TestSteps, %{}},
-      "I return ok tuple with map" => {TestSteps, %{}},
-      "I return ok tuple with keyword" => {TestSteps, %{}},
-      "I return error tuple" => {TestSteps, %{}},
-      "I return invalid value" => {TestSteps, %{}},
-      "I have {int} items" => {TestSteps, %{}},
-      "I access the datatable" => {TestSteps, %{}},
-      "I access the docstring" => {TestSteps, %{}}
-    }
+    step_registry =
+      for {pattern, metadata} <- TestSteps.__cucumber_steps__(), into: %{} do
+        {{:expression, pattern}, {TestSteps, metadata}}
+      end
 
     base_context = %{
       feature_file: "test/features/example.feature",

--- a/test/cucumber/step_definition_test.exs
+++ b/test/cucumber/step_definition_test.exs
@@ -1,6 +1,18 @@
 defmodule Cucumber.StepDefinitionTest do
   use ExUnit.Case, async: true
 
+  # Runs a single step text against a module's definitions through the real
+  # runtime dispatch (the same path generated feature tests use).
+  defp run_step(module, text, context \\ %{}) do
+    registry =
+      for {pattern, metadata} <- module.__cucumber_steps__(), into: %{} do
+        {{:expression, pattern}, {module, metadata}}
+      end
+
+    step = %Gherkin.Step{keyword: "Given", text: text, line: 1}
+    Cucumber.Runtime.execute_step(context, step, registry)
+  end
+
   describe "step macro" do
     test "registers step with pattern and metadata" do
       defmodule RegisterTestSteps do
@@ -81,13 +93,13 @@ defmodule Cucumber.StepDefinitionTest do
       steps = NoContextModule.__cucumber_steps__()
       assert length(steps) == 1
 
-      result = NoContextModule.step(%{some: "data"}, "I have no context")
-      assert result == :ok
+      result = run_step(NoContextModule, "I have no context", %{some: "data"})
+      assert result.some == "data"
     end
   end
 
-  describe "generated step/2 function" do
-    test "matches step text and returns result" do
+  describe "dispatch through Cucumber.Runtime" do
+    test "matches step text and merges the result into context" do
       defmodule MatchingSteps do
         use Cucumber.StepDefinition
 
@@ -96,8 +108,9 @@ defmodule Cucumber.StepDefinitionTest do
         end
       end
 
-      result = MatchingSteps.step(%{existing: "data"}, "I return a value")
-      assert result == %{returned: true}
+      result = run_step(MatchingSteps, "I return a value", %{existing: "data"})
+      assert result.returned == true
+      assert result.existing == "data"
     end
 
     test "extracts parameters and passes via context.args" do
@@ -110,8 +123,9 @@ defmodule Cucumber.StepDefinitionTest do
         end
       end
 
-      result = ParameterSteps.step(%{}, "I have 5 items costing 19.99")
-      assert result == %{count: 5, price: 19.99}
+      result = run_step(ParameterSteps, "I have 5 items costing 19.99")
+      assert result.count == 5
+      assert result.price == 19.99
     end
 
     test "extracts string parameters" do
@@ -124,8 +138,8 @@ defmodule Cucumber.StepDefinitionTest do
         end
       end
 
-      result = StringParamSteps.step(%{}, "I enter \"john_doe\" as username")
-      assert result == %{username: "john_doe"}
+      result = run_step(StringParamSteps, "I enter \"john_doe\" as username")
+      assert result.username == "john_doe"
     end
 
     test "raises when no step matches" do
@@ -137,13 +151,13 @@ defmodule Cucumber.StepDefinitionTest do
         end
       end
 
-      assert_raise RuntimeError, ~r/No step definition found/, fn ->
-        NoMatchSteps.step(%{}, "I do not exist")
+      assert_raise Cucumber.StepError, ~r/No matching step definition found/, fn ->
+        run_step(NoMatchSteps, "I do not exist")
       end
     end
 
-    test "matches first defined step when multiple could match" do
-      defmodule FirstMatchSteps do
+    test "raises AmbiguousStepError when multiple definitions match" do
+      defmodule OverlappingSteps do
         use Cucumber.StepDefinition
 
         step "I have {int} items", context do
@@ -155,8 +169,13 @@ defmodule Cucumber.StepDefinitionTest do
         end
       end
 
-      result = FirstMatchSteps.step(%{}, "I have 5 items")
-      assert result.matched == :first
+      error =
+        assert_raise Cucumber.AmbiguousStepError, fn ->
+          run_step(OverlappingSteps, "I have 5 items")
+        end
+
+      assert error.message =~ ~s("I have {int} items")
+      assert error.message =~ ~s("I have 5 items")
     end
   end
 

--- a/test/fixtures/cck/ambiguous/ambiguous.feature
+++ b/test/fixtures/cck/ambiguous/ambiguous.feature
@@ -1,0 +1,6 @@
+Feature: Ambiguous steps
+  Multiple step definitions that match a pickle step result in an AMBIGUOUS status, since Cucumber cannot determine
+  which one to execute.
+
+  Scenario: Multiple step definitions for a step
+    Given a step with multiple definitions

--- a/test/support/behavior_case.ex
+++ b/test/support/behavior_case.ex
@@ -155,7 +155,7 @@ defmodule Cucumber.BehaviorCase do
     for module <- step_modules,
         {pattern, metadata} <- module.__cucumber_steps__(),
         into: %{} do
-      {pattern, {module, metadata}}
+      {{:expression, pattern}, {module, metadata}}
     end
   end
 


### PR DESCRIPTION
Closes #20. Closes #22.

Roadmap PR 2. Three related changes that consolidate step matching into one place and make failures point at the right code:

## Ambiguous step detection (#20)

Step resolution now collects **all** matching definitions. More than one match raises a new `Cucumber.AmbiguousStepError` that lists every matching pattern with its definition site (`file:line` from registry metadata) and fails the scenario. Previously the first match (in map iteration order!) executed and the scenario passed silently — the worst kind of wrong, caught originally by the CCK `ambiguous` sample.

Ambiguity is a runtime property of a concrete step text (two patterns can overlap for one input but not another), so it's detected at resolution time; the discovery-time exact-duplicate check is unchanged. The distinct exception type is deliberate: retry (#26) must never retry ambiguous steps, and messages (#28) report AMBIGUOUS rather than FAILED.

## Feature-file stack traces (#22)

The reported stacktrace for a failing, undefined, or ambiguous step now leads with a synthetic frame pointing at the **feature file and the failing step's line**, followed by the step definition's own frame; internal `Cucumber.Runtime` frames are filtered out. Undefined-step errors previously pointed at `runtime.ex:70`, which told the user nothing.

## Single matching path

The runtime previously matched a step against the registry to extract args, then called the module's generated `step/2` dispatcher — which re-ran its own first-match loop. Dispatch now goes straight to the matched function via registry metadata, and the generated dispatcher is **removed**, so matching semantics (including ambiguity) exist in exactly one place — a prerequisite for regex steps (#24) and custom parameter types (#23).

Two internal shape changes, both CHANGELOG'd as breaking for 0.x:
- Registry keys are now `{:expression, source}` tuples (final shape; `{:regex, source}` joins in #24).
- Generated feature modules read the registry/hooks from `:persistent_term` (per-compilation keys) instead of `Macro.escape`-ing full copies into every module AST.

## Behavior coverage

- CCK `ambiguous` fixture vendored: error names both patterns and both `file:line` sites; neither definition executes.
- Overlapping-but-non-colliding patterns produce no false positive.
- Ambiguous background step fails every scenario; steps after an ambiguous step never run (collector-verified).
- Return-value matrix re-asserted through the new dispatch (existing behavior tests).
- Stack frames asserted first-frame-is-feature-file for failing steps, missing steps, and the CCK `stack-traces` fixture (which specifies exactly this).
- Existing `runtime`/`discovery`/`step_definition` unit tests updated to the registry shape; the old "first match wins" test now asserts `AmbiguousStepError` instead.

`mix precommit` green: 245 tests (was 239).