### PR TITLE
Add the Rule keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### New Features
 
+- **The Rule keyword** (#19). Rules group related scenarios under a feature; each rule can carry its own description, tags, and `Background:`. Rule-background steps run after the feature background for every scenario in the rule (spec order: feature background → rule background → scenario steps), rule tags are inherited by the rule's scenarios (so they participate in ExUnit tag filtering and tagged hooks), and `Example:` is accepted as a synonym for `Scenario:`. Parsed rules live on the new `Gherkin.Feature.rules` field as `Gherkin.Rule` structs; test names for scenarios inside a rule are prefixed with the rule name so identically-named scenarios in different rules don't collide.
 - **Backtick docstrings and media types** (#18). Docstrings can be delimited with ``` ``` ``` as an alternative to `"""`; the closing delimiter must match the opening one, and either delimiter style is plain content inside the other. An optional media type may follow the opening delimiter (e.g. ` ```json `) and is available as `Gherkin.Step.docstring_media_type` and `context.docstring_media_type` in step definitions. `context.docstring` remains a plain string.
 
 ### Improvements

--- a/docs/feature_files.md
+++ b/docs/feature_files.md
@@ -186,6 +186,27 @@ Scenario: Adding an item to an empty cart
   Then my cart should contain 1 item
 ```
 
+### Rules
+
+The `Rule:` keyword groups related scenarios under a business rule. A rule can
+have its own description, tags, and `Background:`; rule-background steps run
+after the feature background for each scenario in the rule, and rule tags are
+inherited by those scenarios. `Example:` is accepted as a synonym for
+`Scenario:`:
+
+```gherkin
+Feature: Chocolate sales
+
+  Rule: A sale cannot happen if the customer has no money
+    Background:
+      Given there are chocolate bars in stock
+
+    Example: Not enough money
+      Given the customer has 100 cents
+      When the customer tries to buy a 125 cent chocolate bar
+      Then the sale should not happen
+```
+
 ## File Organization
 
 Feature files should be placed in a `test/features/` directory and have a `.feature` extension. Organize them logically by feature or domain area:

--- a/lib/cucumber/compiler.ex
+++ b/lib/cucumber/compiler.ex
@@ -91,9 +91,9 @@ defmodule Cucumber.Compiler do
           # If there's a background or feature-level tags, create setup block
           unquote(generate_setup(feature.background, step_registry, feature))
 
-          # Expand scenario outlines and generate test for each scenario
+          # Expand scenario outlines and rules, generate test for each scenario
           unquote_splicing(
-            for scenario <- expand_all_scenarios(feature.scenarios) do
+            for scenario <- expand_feature(feature) do
               generate_scenario_test(scenario, step_registry, all_hooks, feature, async)
             end
           )
@@ -111,15 +111,19 @@ defmodule Cucumber.Compiler do
   # synthetic stacktrace makes editors highlight the warning on the feature
   # file itself rather than inside the cucumber library.
   def warn_on_empty_feature(%{scenarios: []} = feature) do
-    stacktrace = [
-      {__MODULE__, :compile_feature, 3, [file: String.to_charlist(feature.file), line: 1]}
-    ]
+    if Map.get(feature, :rules, []) == [] do
+      stacktrace = [
+        {__MODULE__, :compile_feature, 3, [file: String.to_charlist(feature.file), line: 1]}
+      ]
 
-    IO.warn(
-      "Cucumber: feature file #{feature.file} parsed with zero scenarios — " <>
-        "scenarios may have been silently dropped by the parser.",
-      stacktrace
-    )
+      IO.warn(
+        "Cucumber: feature file #{feature.file} parsed with zero scenarios — " <>
+          "scenarios may have been silently dropped by the parser.",
+        stacktrace
+      )
+    else
+      :ok
+    end
   end
 
   def warn_on_empty_feature(_feature), do: :ok
@@ -284,7 +288,40 @@ defmodule Cucumber.Compiler do
     end
   end
 
-  # Scenario Outline expansion functions
+  # Scenario Outline and Rule expansion functions
+
+  @doc false
+  # Public for testing - expands a feature's scenarios and rules into the
+  # flat list of concrete scenarios that become tests.
+  @spec expand_feature(map()) :: [Gherkin.Scenario.t()]
+  def expand_feature(feature) do
+    rules = Map.get(feature, :rules, [])
+    expand_all_scenarios(feature.scenarios) ++ Enum.flat_map(rules, &expand_rule/1)
+  end
+
+  # Scenarios inside a rule get the rule background's steps prepended (the
+  # feature background stays in the module's setup block, preserving the
+  # spec order: feature background, rule background, scenario steps), the
+  # rule's tags merged in, and the rule name prefixed so identically-named
+  # scenarios in different rules don't collide as ExUnit test names.
+  defp expand_rule(%Gherkin.Rule{} = rule) do
+    rule_background_steps = if rule.background, do: rule.background.steps, else: []
+
+    rule.scenarios
+    |> expand_all_scenarios()
+    |> Enum.map(fn %Scenario{} = scenario ->
+      %Scenario{
+        scenario
+        | name: prefix_with_rule(rule.name, scenario.name),
+          steps: rule_background_steps ++ scenario.steps,
+          tags: Enum.uniq(rule.tags ++ scenario.tags),
+          rule: rule.name
+      }
+    end)
+  end
+
+  defp prefix_with_rule("", scenario_name), do: scenario_name
+  defp prefix_with_rule(rule_name, scenario_name), do: "#{rule_name}: #{scenario_name}"
 
   @doc false
   # Public for testing - expands scenario outlines into concrete scenarios

--- a/lib/gherkin.ex
+++ b/lib/gherkin.ex
@@ -3,17 +3,39 @@ defmodule Gherkin.Feature do
   Represents a parsed Gherkin feature file (minimal subset).
 
   A Feature is the top-level element in a Gherkin file, containing a name,
-  optional description, optional background, and one or more scenarios.
+  optional description, optional background, scenarios, and rules.
   It can also have tags that apply to all scenarios in the feature.
   """
-  defstruct name: "", description: "", background: nil, scenarios: [], tags: []
+  defstruct name: "", description: "", background: nil, scenarios: [], rules: [], tags: []
 
   @type t :: %__MODULE__{
           name: String.t(),
           description: String.t(),
           background: Gherkin.Background.t() | nil,
           scenarios: [Gherkin.Scenario.t() | Gherkin.ScenarioOutline.t()],
+          rules: [Gherkin.Rule.t()],
           tags: [String.t()]
+        }
+end
+
+defmodule Gherkin.Rule do
+  @moduledoc """
+  Represents a Gherkin Rule section.
+
+  A Rule groups related scenarios under a feature to express a business rule.
+  It can have its own description, tags, and Background; rule-background steps
+  run after the feature-background steps for each scenario in the rule, and
+  rule tags are inherited by those scenarios.
+  """
+  defstruct name: "", description: "", background: nil, scenarios: [], tags: [], line: nil
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          description: String.t(),
+          background: Gherkin.Background.t() | nil,
+          scenarios: [Gherkin.Scenario.t() | Gherkin.ScenarioOutline.t()],
+          tags: [String.t()],
+          line: non_neg_integer() | nil
         }
 end
 
@@ -39,16 +61,18 @@ defmodule Gherkin.Scenario do
   A Scenario is a concrete example that illustrates a business rule.
   It consists of a name, an optional free-form description, a list of steps,
   optional tags for filtering, and the line number where it appears in the
-  source file.
+  source file. When a scenario was defined inside a `Rule`, `rule` carries
+  the rule's name (set during compilation, not by the parser).
   """
-  defstruct name: "", description: "", steps: [], tags: [], line: nil
+  defstruct name: "", description: "", steps: [], tags: [], line: nil, rule: nil
 
   @type t :: %__MODULE__{
           name: String.t(),
           description: String.t(),
           steps: [Gherkin.Step.t()],
           tags: [String.t()],
-          line: non_neg_integer() | nil
+          line: non_neg_integer() | nil,
+          rule: String.t() | nil
         }
 end
 

--- a/lib/gherkin/parser.ex
+++ b/lib/gherkin/parser.ex
@@ -18,7 +18,7 @@ defmodule Gherkin.NimbleParser do
 
   import NimbleParsec
 
-  alias Gherkin.{Background, Examples, Feature, Scenario, ScenarioOutline, Step}
+  alias Gherkin.{Background, Examples, Feature, Rule, Scenario, ScenarioOutline, Step}
 
   # ============================================================
   # LEVEL 1: PRIMITIVES
@@ -87,9 +87,16 @@ defmodule Gherkin.NimbleParser do
     string("Background:")
     |> label("Background:")
 
+  # "Example:" is the spec synonym for "Scenario:". No conflict with
+  # "Examples:" — the colon position differs, so neither prefix-matches
+  # the other.
   scenario_keyword =
-    string("Scenario:")
+    choice([string("Scenario:"), string("Example:")])
     |> label("Scenario:")
+
+  rule_keyword =
+    string("Rule:")
+    |> label("Rule:")
 
   scenario_outline_keyword =
     choice([string("Scenario Outline:"), string("Scenario Template:")])
@@ -203,6 +210,7 @@ defmodule Gherkin.NimbleParser do
       scenario_keyword,
       scenario_outline_keyword,
       examples_keyword,
+      rule_keyword,
       # Tag line indicates new section
       string("@")
     ])
@@ -255,6 +263,7 @@ defmodule Gherkin.NimbleParser do
         scenario_keyword,
         scenario_outline_keyword,
         examples_keyword,
+        rule_keyword,
         string("@")
       ])
     )
@@ -279,6 +288,7 @@ defmodule Gherkin.NimbleParser do
         scenario_keyword,
         scenario_outline_keyword,
         examples_keyword,
+        rule_keyword,
         string("@"),
         string("|"),
         string(~s(""")),
@@ -384,6 +394,26 @@ defmodule Gherkin.NimbleParser do
       scenario
     ])
 
+  # --- Rule ---
+  rule_name =
+    ignore(rule_keyword)
+    |> concat(rest_of_line)
+
+  # A rule groups scenarios and may carry its own background. Scenarios
+  # following a Rule: header belong to that rule (rules cannot be "closed",
+  # so each rule's repeat consumes everything until the next Rule: or EOF).
+  rule =
+    ignore(blank_lines)
+    |> concat(tags |> tag(:tags))
+    |> concat(optional_ws)
+    |> line(rule_name)
+    |> concat(eol)
+    |> concat(section_description)
+    |> optional(background)
+    |> concat(repeat(scenario_definition) |> tag(:scenarios))
+    |> reduce({__MODULE__, :build_rule, []})
+    |> label("rule section")
+
   # ============================================================
   # LEVEL 6: FEATURE
   # ============================================================
@@ -404,6 +434,7 @@ defmodule Gherkin.NimbleParser do
     |> concat(feature_description)
     |> optional(background)
     |> concat(repeat(scenario_definition) |> tag(:scenarios))
+    |> concat(repeat(rule) |> tag(:rules))
     |> reduce({__MODULE__, :build_feature, []})
     |> label("feature")
 
@@ -588,6 +619,9 @@ defmodule Gherkin.NimbleParser do
   defp extract_scenario_name(args),
     do: extract_name_from_args(args, [:tags, :steps, :examples, :description])
 
+  defp extract_rule_name(args),
+    do: extract_name_from_args(args, [:tags, :description, :background, :scenarios])
+
   defp extract_name_from_args([{tag, _} | rest], skip_tags) when is_atom(tag) do
     if tag in skip_tags,
       do: extract_name_from_args(rest, skip_tags),
@@ -641,18 +675,37 @@ defmodule Gherkin.NimbleParser do
   end
 
   @doc false
+  def build_rule(args) do
+    tags = extract_tagged(args, :tags)
+    scenarios = extract_tagged(args, :scenarios)
+    background = extract_tagged_single(args, :background)
+    {name, line_num} = extract_rule_name(args)
+
+    %Rule{
+      name: name,
+      description: extract_tagged_single(args, :description) || "",
+      tags: tags,
+      background: background,
+      scenarios: scenarios,
+      line: if(line_num, do: line_num - 1, else: nil)
+    }
+  end
+
+  @doc false
   def build_feature(args) do
     tags = extract_tagged(args, :tags)
     name = extract_tagged_single(args, :name) || ""
     background = extract_tagged_single(args, :background)
     scenarios = extract_tagged(args, :scenarios)
+    rules = extract_tagged(args, :rules)
 
     %Feature{
       name: name,
       description: extract_tagged_single(args, :description) || "",
       tags: tags,
       background: background,
-      scenarios: scenarios
+      scenarios: scenarios,
+      rules: rules
     }
   end
 

--- a/test/cucumber/behavior/rules_test.exs
+++ b/test/cucumber/behavior/rules_test.exs
@@ -1,0 +1,198 @@
+defmodule Cucumber.RulesBehaviorTest do
+  @moduledoc """
+  Behavior tests for the Rule keyword (#19), driven by the CCK `rules` and
+  `rules-backgrounds` samples plus targeted cases from the issue checklist.
+  """
+
+  use Cucumber.BehaviorCase
+
+  alias Cucumber.BehaviorCase.Collector
+
+  defmodule ChocolateSteps do
+    use Cucumber.StepDefinition
+    import ExUnit.Assertions
+
+    step "the customer has {int} cents", %{args: [money]} do
+      %{money: money}
+    end
+
+    step "there are chocolate bars in stock", _context do
+      %{stock: ["Mars"]}
+    end
+
+    step "there are no chocolate bars in stock", _context do
+      %{stock: []}
+    end
+
+    step "the customer tries to buy a {int} cent chocolate bar", %{args: [price]} = context do
+      if context.money >= price do
+        %{chocolate: List.first(context.stock)}
+      else
+        :ok
+      end
+    end
+
+    step "the sale should not happen", context do
+      assert Map.get(context, :chocolate) == nil
+      :ok
+    end
+
+    step "the sale should happen", context do
+      assert context.chocolate
+      :ok
+    end
+  end
+
+  defmodule OrderSteps do
+    use Cucumber.StepDefinition
+
+    step "an order for {string}", %{args: [item]} do
+      Collector.record({:order, item})
+      :ok
+    end
+
+    step "an action", _context do
+      Collector.record(:action)
+      :ok
+    end
+
+    step "an outcome", _context do
+      Collector.record(:outcome)
+      :ok
+    end
+  end
+
+  defmodule MarkerSteps do
+    use Cucumber.StepDefinition
+
+    step "a marker step in {string}", %{args: [where]} do
+      Collector.record({:marker, where})
+      :ok
+    end
+
+    step "a failing rule background step", _context do
+      raise "rule background boom"
+    end
+  end
+
+  defmodule RuleTagHooks do
+    use Cucumber.Hooks
+
+    before_scenario "@some-tag", context do
+      Collector.record(:rule_tagged_hook)
+      {:ok, context}
+    end
+  end
+
+  defp fixture(sample) do
+    File.read!(Path.join(["test/fixtures/cck", sample, "#{sample}.feature"]))
+  end
+
+  describe "CCK: rules" do
+    test "scenarios in rules execute with reference outcomes" do
+      run = run_feature(fixture("rules"), steps: [ChocolateSteps])
+
+      # 2 scenarios in the first rule + 1 in the second, all passing
+      assert %{total: 3, passed: 3, failures: 0} = run
+    end
+
+    test "rule tags trigger tagged hooks for the rule's scenarios only" do
+      run = run_feature(fixture("rules"), steps: [ChocolateSteps], hooks: [RuleTagHooks])
+
+      assert %{total: 3, passed: 3} = run
+      # Only the one scenario under the @some-tag rule fires the hook
+      assert Enum.count(run.events, &(&1 == :rule_tagged_hook)) == 1
+    end
+  end
+
+  describe "CCK: rules-backgrounds" do
+    test "feature background runs before rule background before scenario steps" do
+      run = run_feature(fixture("rules-backgrounds"), steps: [OrderSteps])
+
+      assert %{total: 2, passed: 2, failures: 0} = run
+
+      expected_scenario_events = [
+        {:order, "eggs"},
+        {:order, "milk"},
+        {:order, "bread"},
+        {:order, "batteries"},
+        {:order, "light bulbs"},
+        :action,
+        :outcome
+      ]
+
+      assert Enum.chunk_every(run.events, 7) == [
+               expected_scenario_events,
+               expected_scenario_events
+             ]
+    end
+  end
+
+  describe "rule semantics" do
+    test "identically-named scenarios in different rules both run" do
+      run =
+        run_feature(
+          """
+          Feature: name collisions
+            Rule: first rule
+              Scenario: same name
+                Given a marker step in "first"
+
+            Rule: second rule
+              Scenario: same name
+                Given a marker step in "second"
+          """,
+          steps: [MarkerSteps]
+        )
+
+      assert %{total: 2, passed: 2, failures: 0} = run
+      assert Enum.sort(run.events) == [{:marker, "first"}, {:marker, "second"}]
+    end
+
+    test "a failing rule-background step fails the scenario and reports its line" do
+      run =
+        run_feature(
+          """
+          Feature: failing rule background
+            Rule: doomed
+              Background:
+                Given a failing rule background step
+
+              Scenario: never gets here
+                Given a marker step in "unreachable"
+          """,
+          steps: [MarkerSteps],
+          file: "test/fixtures/generated/rule_background.feature"
+        )
+
+      assert %{total: 1, passed: 0, failures: 1} = run
+      assert run.output =~ "rule background boom"
+      # The failing step's feature-file stack frame points at the rule
+      # background step's line (line 4)
+      assert run.output =~ "rule_background.feature:4"
+      refute {:marker, "unreachable"} in run.events
+    end
+
+    test "rule tags are filterable ExUnit tags on the generated tests" do
+      run =
+        run_feature(
+          """
+          Feature: tagged rule
+            @wip-rule
+            Rule: tagged
+              Scenario: carries the rule tag
+                Given a marker step in "tagged"
+          """,
+          steps: [MarkerSteps]
+        )
+
+      assert %{total: 1, passed: 1} = run
+
+      # The generated test carries the rule tag as an ExUnit tag
+      test_name = :"test tagged: carries the rule tag"
+      %ExUnit.TestModule{tests: tests} = run.module.__ex_unit__()
+      test_tags = Enum.find(tests, &(&1.name == test_name)).tags
+      assert test_tags[:"wip-rule"] == true
+    end
+  end
+end

--- a/test/features/rules.feature
+++ b/test/features/rules.feature
@@ -1,0 +1,20 @@
+Feature: Rules group related scenarios
+  Rules express a business rule with its own examples.
+
+  Background:
+    Given a ledger entry for "feature setup"
+
+  Rule: Totals accumulate ledger entries
+    Rule backgrounds run after the feature background.
+
+    Background:
+      Given a ledger entry for "rule setup"
+
+    Example: both backgrounds apply
+      When I total the ledger
+      Then the ledger total is 2
+
+  Rule: Rules can use the Scenario keyword too
+    Scenario: only the feature background applies
+      When I total the ledger
+      Then the ledger total is 1

--- a/test/features/step_definitions/rules_steps.exs
+++ b/test/features/step_definitions/rules_steps.exs
@@ -1,0 +1,17 @@
+defmodule RulesSteps do
+  use Cucumber.StepDefinition
+  import ExUnit.Assertions
+
+  step "a ledger entry for {string}", %{args: [entry]} = context do
+    %{ledger: Map.get(context, :ledger, []) ++ [entry]}
+  end
+
+  step "I total the ledger", context do
+    %{ledger_total: length(context.ledger)}
+  end
+
+  step "the ledger total is {int}", %{args: [expected]} = context do
+    assert context.ledger_total == expected
+    :ok
+  end
+end

--- a/test/fixtures/cck/failedish-combinations/failedish-combinations.feature
+++ b/test/fixtures/cck/failedish-combinations/failedish-combinations.feature
@@ -1,0 +1,54 @@
+Feature: Failed-ish combinations
+  Sometimes the first failed-ish (not passed or skipped) step's status
+  is not the only one.
+
+  Rule: Undefined and ambiguous steps can follow a failed-ish step
+
+    Scenario: Pending as the first failed-ish step
+      Given a pending step
+      And an undefined step
+      And an ambiguous step
+
+    Scenario: Undefined as the first failed-ish step
+      Given an undefined step
+      And an undefined step
+      And an ambiguous step
+
+    Scenario: Ambiguous as the first failed-ish step
+      Given an ambiguous step
+      And an undefined step
+      And an ambiguous step
+
+    Scenario: Failed as the first failed-ish step
+      Given a failing step
+      And an undefined step
+      And an ambiguous step
+
+  Rule: Failed and pending steps do not follow a failed-ish step
+
+    Scenario: Pending as the first failed-ish step
+      Given a pending step
+      And a pending step
+      And a failing step
+
+    Scenario: Undefined as the first failed-ish step
+      Given an undefined step
+      And a pending step
+      And a failing step
+
+    Scenario: Ambiguous as the first failed-ish step
+      Given an ambiguous step
+      And a pending step
+      And a failing step
+
+    Scenario: Failed as the first failed-ish step
+      Given a failing step
+      And a pending step
+      And a failing step
+
+  Rule: No pickle steps follow a skipped step
+
+    Scenario: Step marks itself skipped
+      Given a skipped step
+      And an undefined step
+      And an ambiguous step

--- a/test/fixtures/cck/rules-backgrounds/rules-backgrounds.feature
+++ b/test/fixtures/cck/rules-backgrounds/rules-backgrounds.feature
@@ -1,0 +1,23 @@
+Feature: Rules with Backgrounds
+  Like Features, Rules can also have Backgrounds, whose steps are prepended to those of each child Scenario. Only
+  one Background at the Rule level is supported.
+
+  It's even possible to have a Background at both Feature and Rule level, in which case they are concatenated.
+
+  Background:
+    Given an order for "eggs"
+    And an order for "milk"
+    And an order for "bread"
+
+  Rule:
+    Background:
+      Given an order for "batteries"
+      And an order for "light bulbs"
+
+    Example: one scenario
+      When an action
+      Then an outcome
+
+    Example: another scenario
+      When an action
+      Then an outcome

--- a/test/fixtures/cck/rules/rules.feature
+++ b/test/fixtures/cck/rules/rules.feature
@@ -1,0 +1,29 @@
+Feature: Usage of a `Rule`
+  You can place scenarios inside rules. This makes it possible to structure Gherkin documents
+  in the same way as [example maps](https://cucumber.io/blog/bdd/example-mapping-introduction/).
+
+  You can also use the Examples synonym for Scenario to make them even similar.
+
+  Rule: A sale cannot happen if the customer does not have enough money
+    # Unhappy path
+    Example: Not enough money
+      Given the customer has 100 cents
+      And there are chocolate bars in stock
+      When the customer tries to buy a 125 cent chocolate bar
+      Then the sale should not happen
+
+    # Happy path
+    Example: Enough money
+      Given the customer has 100 cents
+      And there are chocolate bars in stock
+      When the customer tries to buy a 75 cent chocolate bar
+      Then the sale should happen
+
+  @some-tag
+  Rule: a sale cannot happen if there is no stock
+    # Unhappy path
+    Example: No chocolates left
+      Given the customer has 100 cents
+      And there are no chocolate bars in stock
+      When the customer tries to buy a 1 cent chocolate bar
+      Then the sale should not happen

--- a/test/gherkin_rules_test.exs
+++ b/test/gherkin_rules_test.exs
@@ -1,0 +1,171 @@
+defmodule GherkinRulesTest do
+  use ExUnit.Case, async: true
+
+  alias Gherkin.Parser
+
+  describe "Rule parsing" do
+    test "a rule groups its scenarios with name, description, and tags" do
+      feature =
+        Parser.parse("""
+        Feature: F
+
+          @rule-tag
+          Rule: A sale cannot happen without money
+            The rule description.
+
+            Scenario: no money
+              Given no money
+
+            Scenario: enough money
+              Given enough money
+        """)
+
+      assert feature.scenarios == []
+      assert [rule] = feature.rules
+      assert rule.name == "A sale cannot happen without money"
+      assert rule.description == "The rule description."
+      assert rule.tags == ["rule-tag"]
+      assert Enum.map(rule.scenarios, & &1.name) == ["no money", "enough money"]
+      assert rule.line == 3
+    end
+
+    test "Example: is a synonym for Scenario:, and Examples: still parses tables" do
+      feature =
+        Parser.parse("""
+        Feature: F
+
+          Rule: examples synonym
+            Example: written as Example
+              Given a step
+
+          Scenario Outline: outline still works
+            Given <thing>
+
+            Examples:
+              | thing |
+              | a     |
+        """)
+
+      # Note: the bare outline precedes the rule in source order? It does not —
+      # scenarios after a Rule belong to the rule. This source puts the outline
+      # AFTER the rule, so it nests inside it.
+      assert [rule] = feature.rules
+      assert [example, outline] = rule.scenarios
+      assert %Gherkin.Scenario{name: "written as Example"} = example
+      assert %Gherkin.ScenarioOutline{name: "outline still works"} = outline
+      assert [%Gherkin.Examples{table_body: [["a"]]}] = outline.examples
+    end
+
+    test "rules can have their own background" do
+      feature =
+        Parser.parse("""
+        Feature: F
+
+          Background:
+            Given a feature-level order
+
+          Rule: with background
+            Background:
+              Given a rule-level order
+
+            Example: one
+              When an action
+        """)
+
+      assert [%Gherkin.Step{text: "a feature-level order"}] = feature.background.steps
+      assert [rule] = feature.rules
+      assert [%Gherkin.Step{text: "a rule-level order"}] = rule.background.steps
+    end
+
+    test "a rule may have an empty name (CCK rules-backgrounds shape)" do
+      feature =
+        Parser.parse("""
+        Feature: F
+
+          Rule:
+            Example: anonymous rule scenario
+              Given a step
+        """)
+
+      assert [rule] = feature.rules
+      assert rule.name == ""
+      assert [%Gherkin.Scenario{name: "anonymous rule scenario"}] = rule.scenarios
+    end
+
+    test "bare scenarios and rules coexist; scenarios after a rule belong to it" do
+      feature =
+        Parser.parse("""
+        Feature: F
+
+          Scenario: feature-level scenario
+            Given a step
+
+          Rule: first rule
+            Scenario: inside first
+              Given a step
+
+          Rule: second rule
+            Scenario: inside second
+              Given a step
+
+            Scenario: also inside second
+              Given a step
+        """)
+
+      assert [%Gherkin.Scenario{name: "feature-level scenario"}] = feature.scenarios
+      assert [first, second] = feature.rules
+      assert Enum.map(first.scenarios, & &1.name) == ["inside first"]
+      assert Enum.map(second.scenarios, & &1.name) == ["inside second", "also inside second"]
+    end
+
+    test "comments between rule scenarios are skipped (CCK rules shape)" do
+      feature =
+        Parser.parse("""
+        Feature: F
+
+          Rule: with comments
+            # Unhappy path
+            Example: one
+              Given a step
+
+            # Happy path
+            Example: two
+              Given a step
+        """)
+
+      assert [rule] = feature.rules
+      assert length(rule.scenarios) == 2
+    end
+
+    test "the CCK rules fixtures parse with expected structure" do
+      rules =
+        "test/fixtures/cck/rules/rules.feature"
+        |> File.read!()
+        |> Parser.parse()
+
+      assert length(rules.rules) == 2
+      assert [r1, r2] = rules.rules
+      assert length(r1.scenarios) == 2
+      assert length(r2.scenarios) == 1
+      assert r2.tags == ["some-tag"]
+
+      backgrounds =
+        "test/fixtures/cck/rules-backgrounds/rules-backgrounds.feature"
+        |> File.read!()
+        |> Parser.parse()
+
+      assert backgrounds.background
+      assert [rule] = backgrounds.rules
+      assert length(rule.background.steps) == 2
+      assert length(rule.scenarios) == 2
+
+      failedish =
+        "test/fixtures/cck/failedish-combinations/failedish-combinations.feature"
+        |> File.read!()
+        |> Parser.parse()
+
+      assert length(failedish.rules) == 3
+      assert Enum.map(failedish.rules, &length(&1.scenarios)) == [4, 4, 1]
+    end
+  end
+end

--- a/test/gherkin_test.exs
+++ b/test/gherkin_test.exs
@@ -492,6 +492,7 @@ defmodule Gherkin.ParserTest do
         "test/features/hook_execution_order.feature" => 1,
         "test/features/parameters.feature" => 4,
         "test/features/return_values.feature" => 4,
+        "test/features/rules.feature" => 2,
         "test/features/scenario_outline.feature" => 2,
         "test/features/shared_steps_integration.feature" => 2,
         "test/features/simple.feature" => 1,
@@ -507,8 +508,12 @@ defmodule Gherkin.ParserTest do
         content = File.read!(file)
         result = Gherkin.Parser.parse(content)
 
-        assert length(result.scenarios) == expected_count,
-               "#{file}: expected #{expected_count} scenarios, got #{length(result.scenarios)}"
+        count =
+          length(result.scenarios) +
+            (result.rules |> Enum.map(&length(&1.scenarios)) |> Enum.sum())
+
+        assert count == expected_count,
+               "#{file}: expected #{expected_count} scenarios (incl. rules), got #{count}"
       end
     end
   end


### PR DESCRIPTION
Closes #19.

Roadmap PR 3. `Rule:` is the last missing piece of standard Gherkin structure.

## Parser

- New `Gherkin.Rule` struct (name, description, tags, background, scenarios, line) on a new `Feature.rules` field — rules are not mixed into `feature.scenarios`, so the published typespec stays truthful.
- Scenarios following a `Rule:` header belong to that rule (rules can't be "closed", matching the spec): the feature grammar is background → bare scenarios → rules, with each rule consuming its scenarios until the next `Rule:` or EOF.
- `Example:` accepted as a synonym for `Scenario:`. No conflict with `Examples:` — the colon position differs, so neither prefix-matches the other (tested both directions).
- Rules can have empty names (the CCK `rules-backgrounds` sample does), descriptions, and tags; `Rule:` joins the step/description terminator lookaheads.

## Compiler

Rules flatten at expansion time:
- Rule-background steps are **prepended to each rule scenario's steps**; the feature background stays in the module's `setup` block — preserving spec order: feature background → rule background → scenario steps (collector-verified in tests).
- Rule tags merge into scenario tags (`Enum.uniq(rule.tags ++ scenario.tags)`), so ExUnit `--only`/`--exclude` filtering and tagged hooks see them.
- Test names get the rule name prefixed — identically-named scenarios in different rules would otherwise be an ExUnit duplicate-test-name compile error.
- Rule provenance is stashed on the expanded scenario (`Scenario.rule`) for pickle generation later (#28).
- The empty-feature warning no longer fires for features whose scenarios all live inside rules.

## Behavior coverage (per the issue checklist)

- CCK `rules` fixture: 3 scenarios across 2 rules, reference outcomes, rule tag fires a tagged hook for exactly its one scenario.
- CCK `rules-backgrounds` fixture: both scenarios see eggs/milk/bread (feature bg) then batteries/light bulbs (rule bg) then action/outcome, in order.
- CCK `failedish-combinations` parses (3 rules; its pending/ambiguous semantics arrive with #21).
- Name collisions across rules, failing rule-background step reporting the rule background's feature line, rule tags as filterable ExUnit tags.
- 7 parser unit tests incl. `Example:`/`Examples:` coexistence and scenarios-after-a-rule nesting.
- Live `test/features/rules.feature` dogfoods feature+rule backgrounds on every `mix test`; the scenario-count test now counts scenarios inside rules.

`mix precommit` green: 260 tests (was 245).