### PR TITLE
Cache loaded modules so repeated discovery keeps its results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ This release completes the Cucumber Compatibility Kit roadmap (#17–#29). Cucum
 - **Step failure stack traces point at the feature file** (#22). The first frame of a failing step's trace is now `feature_file:step_line`, followed by the step definition; internal runtime frames are filtered out.
 - The parser no longer hangs on a feature file that ends in description text.
 - `Cucumber.Hooks.collect_hooks/1` now finds hook modules compiled into the application but not yet loaded (previously they were silently dropped).
-- Repeated discovery in the same VM (e.g. under `mix test.watch`) no longer crashes on already-loaded step files or silently drops hooks and parameter types — `Cucumber.Discovery` now caches each file's modules for the runs where `Code.require_file/1` returns `nil`.
+- Running discovery more than once in the same VM no longer crashes on already-loaded step files or silently drops hooks and parameter types — `Cucumber.Discovery` now caches each file's modules for the passes where `Code.require_file/1` returns `nil`. A step or support file loaded by something other than discovery (where the modules are unknowable) now raises a clear error instead of yielding an empty registry.
 - `context.docstring_media_type` now substitutes scenario outline placeholders, like the docstring content does.
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This release completes the Cucumber Compatibility Kit roadmap (#17–#29). Cucum
 - **Step failure stack traces point at the feature file** (#22). The first frame of a failing step's trace is now `feature_file:step_line`, followed by the step definition; internal runtime frames are filtered out.
 - The parser no longer hangs on a feature file that ends in description text.
 - `Cucumber.Hooks.collect_hooks/1` now finds hook modules compiled into the application but not yet loaded (previously they were silently dropped).
+- Repeated discovery in the same VM (e.g. under `mix test.watch`) no longer crashes on already-loaded step files or silently drops hooks and parameter types — `Cucumber.Discovery` now caches each file's modules for the runs where `Code.require_file/1` returns `nil`.
 - `context.docstring_media_type` now substitutes scenario outline placeholders, like the docstring content does.
 
 ### Improvements

--- a/lib/cucumber/discovery.ex
+++ b/lib/cucumber/discovery.ex
@@ -101,7 +101,7 @@ defmodule Cucumber.Discovery do
     modules =
       patterns
       |> expand_patterns()
-      |> Enum.flat_map(&load_support_modules/1)
+      |> Enum.flat_map(&loaded_modules/1)
 
     hook_modules = Enum.filter(modules, &function_exported?(&1, :__cucumber_hooks__, 0))
 
@@ -111,18 +111,32 @@ defmodule Cucumber.Discovery do
     {hook_modules, parameter_type_modules}
   end
 
-  defp load_support_modules(path), do: loaded_modules(path)
-
   # Code.require_file/1 returns nil when the file was already loaded in this
   # VM, so cache each file's modules on first load; otherwise a second
   # discovery pass would crash on step files and silently drop hooks and
-  # parameter types.
+  # parameter types. Keyed on the expanded path because require_file
+  # dedupes on the expanded path, so two spellings of one file must share
+  # a cache entry.
   defp loaded_modules(path) do
-    cache_key = {__MODULE__, :modules, path}
+    cache_key = {__MODULE__, :modules, Path.expand(path)}
 
     case Code.require_file(path) do
       nil ->
-        :persistent_term.get(cache_key, [])
+        # nil with no cache entry means someone other than discovery loaded
+        # the file, so its modules are unknowable here. (A concurrent
+        # discovery pass racing this one would land here too — loudly,
+        # rather than silently building an empty registry.)
+        case :persistent_term.get(cache_key, :missing) do
+          :missing ->
+            raise "#{path} was already loaded before Cucumber discovery ran, " <>
+                    "so its modules cannot be discovered (Code.require_file/1 " <>
+                    "returns nil for already-loaded files). Remove the earlier " <>
+                    "Code.require_file call and let Cucumber load step and " <>
+                    "support files itself."
+
+          modules ->
+            modules
+        end
 
       modules ->
         module_names = Enum.map(modules, fn {module, _} -> module end)

--- a/lib/cucumber/discovery.ex
+++ b/lib/cucumber/discovery.ex
@@ -111,11 +111,23 @@ defmodule Cucumber.Discovery do
     {hook_modules, parameter_type_modules}
   end
 
-  defp load_support_modules(path) do
-    # Code.require_file returns nil if already loaded
+  defp load_support_modules(path), do: loaded_modules(path)
+
+  # Code.require_file/1 returns nil when the file was already loaded in this
+  # VM, so cache each file's modules on first load; otherwise a second
+  # discovery pass would crash on step files and silently drop hooks and
+  # parameter types.
+  defp loaded_modules(path) do
+    cache_key = {__MODULE__, :modules, path}
+
     case Code.require_file(path) do
-      nil -> []
-      modules -> Enum.map(modules, fn {module, _} -> module end)
+      nil ->
+        :persistent_term.get(cache_key, [])
+
+      modules ->
+        module_names = Enum.map(modules, fn {module, _} -> module end)
+        :persistent_term.put(cache_key, module_names)
+        module_names
     end
   end
 
@@ -148,15 +160,9 @@ defmodule Cucumber.Discovery do
   end
 
   defp load_step_module(path) do
-    # Load the file and get the module
-    modules = Code.require_file(path)
-
-    # Find the step definition module(s)
-    modules
-    |> Enum.map(fn {module, _} -> module end)
-    |> Enum.find(fn module ->
-      function_exported?(module, :__cucumber_steps__, 0)
-    end)
+    path
+    |> loaded_modules()
+    |> Enum.find(&function_exported?(&1, :__cucumber_steps__, 0))
   end
 
   defp build_step_registry(modules, parameter_types) do

--- a/test/cucumber/discovery_test.exs
+++ b/test/cucumber/discovery_test.exs
@@ -445,6 +445,75 @@ defmodule Cucumber.DiscoveryTest do
         File.rm_rf(temp_dir)
       end
     end
+
+    test "serves the cache when a later pass spells the path differently" do
+      temp_dir = Path.join(System.tmp_dir(), "respell_test_#{:rand.uniform(10_000)}")
+      step_dir = Path.join(temp_dir, "steps")
+      File.mkdir_p!(step_dir)
+
+      rand_suffix = :rand.uniform(10_000)
+
+      File.write!(Path.join(step_dir, "steps.exs"), """
+      defmodule RespellSteps#{rand_suffix} do
+        use Cucumber.StepDefinition
+
+        step "a respelled step", context do
+          context
+        end
+      end
+      """)
+
+      base_opts = [support: [], features: []]
+
+      try do
+        first = Discovery.discover([{:steps, [Path.join(step_dir, "*.exs")]} | base_opts])
+
+        # Code.require_file/1 dedupes on the expanded path, so a different
+        # spelling of the same file must hit the same cache entry
+        respelled_pattern = Path.join([temp_dir, ".", "steps", "*.exs"])
+        second = Discovery.discover([{:steps, [respelled_pattern]} | base_opts])
+
+        assert second.step_modules == first.step_modules
+        assert Map.has_key?(second.step_registry, {:expression, "a respelled step"})
+      after
+        File.rm_rf(temp_dir)
+      end
+    end
+
+    test "fails loudly when a file was loaded by someone other than discovery" do
+      temp_dir = Path.join(System.tmp_dir(), "preloaded_test_#{:rand.uniform(10_000)}")
+      step_dir = Path.join(temp_dir, "steps")
+      File.mkdir_p!(step_dir)
+
+      rand_suffix = :rand.uniform(10_000)
+      step_file = Path.join(step_dir, "steps.exs")
+
+      File.write!(step_file, """
+      defmodule PreloadedSteps#{rand_suffix} do
+        use Cucumber.StepDefinition
+
+        step "a preloaded step", context do
+          context
+        end
+      end
+      """)
+
+      try do
+        Code.require_file(step_file)
+
+        # Discovery can't know which modules the earlier load defined, so it
+        # must not silently produce an empty registry
+        assert_raise RuntimeError, ~r/already loaded before Cucumber discovery/, fn ->
+          Discovery.discover(
+            steps: [Path.join(step_dir, "*.exs")],
+            support: [],
+            features: []
+          )
+        end
+      after
+        File.rm_rf(temp_dir)
+      end
+    end
   end
 
   describe "discover/1 with empty patterns" do

--- a/test/cucumber/discovery_test.exs
+++ b/test/cucumber/discovery_test.exs
@@ -464,8 +464,12 @@ defmodule Cucumber.DiscoveryTest do
       first = Discovery.discover([{:steps, [Path.join(step_dir, "*.exs")]} | base_opts])
 
       # Code.require_file/1 dedupes on the expanded path, so a different
-      # spelling of the same file must hit the same cache entry
-      respelled_pattern = Path.join([tmp_dir, ".", "steps", "*.exs"])
+      # spelling of the same file must hit the same cache entry. Relative
+      # vs. absolute survives Path.wildcard (which normalizes "/./" away);
+      # ExUnit's tmp_dir lives under the project root, so a relative
+      # spelling exists
+      respelled_pattern = Path.join(Path.relative_to_cwd(step_dir), "*.exs")
+      refute Path.type(respelled_pattern) == :absolute
       second = Discovery.discover([{:steps, [respelled_pattern]} | base_opts])
 
       assert second.step_modules == first.step_modules

--- a/test/cucumber/discovery_test.exs
+++ b/test/cucumber/discovery_test.exs
@@ -394,6 +394,59 @@ defmodule Cucumber.DiscoveryTest do
     end
   end
 
+  describe "discover/1 repeated discovery" do
+    test "returns the same results when files were already loaded" do
+      temp_dir = Path.join(System.tmp_dir(), "rediscover_test_#{:rand.uniform(10_000)}")
+      step_dir = Path.join(temp_dir, "steps")
+      support_dir = Path.join(temp_dir, "support")
+      File.mkdir_p!(step_dir)
+      File.mkdir_p!(support_dir)
+
+      rand_suffix = :rand.uniform(10_000)
+
+      File.write!(Path.join(step_dir, "steps.exs"), """
+      defmodule RediscoverSteps#{rand_suffix} do
+        use Cucumber.StepDefinition
+
+        step "a rediscovered step", context do
+          context
+        end
+      end
+      """)
+
+      File.write!(Path.join(support_dir, "hooks.exs"), """
+      defmodule RediscoverHooks#{rand_suffix} do
+        use Cucumber.Hooks
+
+        before_scenario context do
+          {:ok, context}
+        end
+      end
+      """)
+
+      opts = [
+        steps: [Path.join(step_dir, "*.exs")],
+        support: [Path.join(support_dir, "*.exs")],
+        features: []
+      ]
+
+      try do
+        first = Discovery.discover(opts)
+        # Code.require_file/1 returns nil for already-loaded files, so a
+        # second pass must serve modules from the cache instead of crashing
+        # or dropping them
+        second = Discovery.discover(opts)
+
+        assert second.step_modules == first.step_modules
+        assert second.step_registry == first.step_registry
+        assert second.hook_modules == first.hook_modules
+        assert Map.has_key?(second.step_registry, {:expression, "a rediscovered step"})
+      after
+        File.rm_rf(temp_dir)
+      end
+    end
+  end
+
   describe "discover/1 with empty patterns" do
     test "returns empty results for non-matching patterns" do
       result =

--- a/test/cucumber/discovery_test.exs
+++ b/test/cucumber/discovery_test.exs
@@ -395,10 +395,10 @@ defmodule Cucumber.DiscoveryTest do
   end
 
   describe "discover/1 repeated discovery" do
-    test "returns the same results when files were already loaded" do
-      temp_dir = Path.join(System.tmp_dir(), "rediscover_test_#{:rand.uniform(10_000)}")
-      step_dir = Path.join(temp_dir, "steps")
-      support_dir = Path.join(temp_dir, "support")
+    @tag :tmp_dir
+    test "returns the same results when files were already loaded", %{tmp_dir: tmp_dir} do
+      step_dir = Path.join(tmp_dir, "steps")
+      support_dir = Path.join(tmp_dir, "support")
       File.mkdir_p!(step_dir)
       File.mkdir_p!(support_dir)
 
@@ -430,25 +430,21 @@ defmodule Cucumber.DiscoveryTest do
         features: []
       ]
 
-      try do
-        first = Discovery.discover(opts)
-        # Code.require_file/1 returns nil for already-loaded files, so a
-        # second pass must serve modules from the cache instead of crashing
-        # or dropping them
-        second = Discovery.discover(opts)
+      first = Discovery.discover(opts)
+      # Code.require_file/1 returns nil for already-loaded files, so a
+      # second pass must serve modules from the cache instead of crashing
+      # or dropping them
+      second = Discovery.discover(opts)
 
-        assert second.step_modules == first.step_modules
-        assert second.step_registry == first.step_registry
-        assert second.hook_modules == first.hook_modules
-        assert Map.has_key?(second.step_registry, {:expression, "a rediscovered step"})
-      after
-        File.rm_rf(temp_dir)
-      end
+      assert second.step_modules == first.step_modules
+      assert second.step_registry == first.step_registry
+      assert second.hook_modules == first.hook_modules
+      assert Map.has_key?(second.step_registry, {:expression, "a rediscovered step"})
     end
 
-    test "serves the cache when a later pass spells the path differently" do
-      temp_dir = Path.join(System.tmp_dir(), "respell_test_#{:rand.uniform(10_000)}")
-      step_dir = Path.join(temp_dir, "steps")
+    @tag :tmp_dir
+    test "serves the cache when a later pass spells the path differently", %{tmp_dir: tmp_dir} do
+      step_dir = Path.join(tmp_dir, "steps")
       File.mkdir_p!(step_dir)
 
       rand_suffix = :rand.uniform(10_000)
@@ -465,24 +461,22 @@ defmodule Cucumber.DiscoveryTest do
 
       base_opts = [support: [], features: []]
 
-      try do
-        first = Discovery.discover([{:steps, [Path.join(step_dir, "*.exs")]} | base_opts])
+      first = Discovery.discover([{:steps, [Path.join(step_dir, "*.exs")]} | base_opts])
 
-        # Code.require_file/1 dedupes on the expanded path, so a different
-        # spelling of the same file must hit the same cache entry
-        respelled_pattern = Path.join([temp_dir, ".", "steps", "*.exs"])
-        second = Discovery.discover([{:steps, [respelled_pattern]} | base_opts])
+      # Code.require_file/1 dedupes on the expanded path, so a different
+      # spelling of the same file must hit the same cache entry
+      respelled_pattern = Path.join([tmp_dir, ".", "steps", "*.exs"])
+      second = Discovery.discover([{:steps, [respelled_pattern]} | base_opts])
 
-        assert second.step_modules == first.step_modules
-        assert Map.has_key?(second.step_registry, {:expression, "a respelled step"})
-      after
-        File.rm_rf(temp_dir)
-      end
+      assert second.step_modules == first.step_modules
+      assert Map.has_key?(second.step_registry, {:expression, "a respelled step"})
     end
 
-    test "fails loudly when a file was loaded by someone other than discovery" do
-      temp_dir = Path.join(System.tmp_dir(), "preloaded_test_#{:rand.uniform(10_000)}")
-      step_dir = Path.join(temp_dir, "steps")
+    @tag :tmp_dir
+    test "fails loudly when a file was loaded by someone other than discovery", %{
+      tmp_dir: tmp_dir
+    } do
+      step_dir = Path.join(tmp_dir, "steps")
       File.mkdir_p!(step_dir)
 
       rand_suffix = :rand.uniform(10_000)
@@ -498,20 +492,16 @@ defmodule Cucumber.DiscoveryTest do
       end
       """)
 
-      try do
-        Code.require_file(step_file)
+      Code.require_file(step_file)
 
-        # Discovery can't know which modules the earlier load defined, so it
-        # must not silently produce an empty registry
-        assert_raise RuntimeError, ~r/already loaded before Cucumber discovery/, fn ->
-          Discovery.discover(
-            steps: [Path.join(step_dir, "*.exs")],
-            support: [],
-            features: []
-          )
-        end
-      after
-        File.rm_rf(temp_dir)
+      # Discovery can't know which modules the earlier load defined, so it
+      # must not silently produce an empty registry
+      assert_raise RuntimeError, ~r/already loaded before Cucumber discovery/, fn ->
+        Discovery.discover(
+          steps: [Path.join(step_dir, "*.exs")],
+          support: [],
+          features: []
+        )
       end
     end
   end


### PR DESCRIPTION
## Problem

`Code.require_file/1` returns `nil` when a file was already loaded in the current VM. Discovery treated that `nil` as "no modules in this file", so running discovery a second time in the same VM:

- **crashed on step files** — `load_step_module/1` called `Enum.map/2` on the `nil`
- **silently dropped hooks and parameter types** — `load_support_modules/1` mapped `nil` to `[]`, so every hook and custom parameter type vanished from the second run

## Fix

Cache each file's modules in `:persistent_term` when the file is first loaded, and serve them from the cache whenever `Code.require_file/1` returns `nil`. Both step and support loading go through the same helper.

Review hardening:

- The cache key is the **expanded** path — `require_file` dedupes on the expanded path, so two spellings of one file must share a cache entry.
- A `nil` with **no cache entry** means something other than discovery loaded the file, making its modules unknowable; discovery now raises a clear, actionable error instead of silently producing an empty registry (previously a crash for step files, a silent drop for support files). A hypothetical concurrent discovery race resolves to this same loud error rather than silent corruption.

## Testing

Behavior tests cover all three paths: a repeat pass returns identical step modules/registry/hooks, a differently-spelled path on a later pass hits the same cache entry, and a file pre-loaded outside discovery raises. `mix precommit` green (501 tests).